### PR TITLE
Disallow shared flag when threads are disabled

### DIFF
--- a/include/wasp/binary/read.h
+++ b/include/wasp/binary/read.h
@@ -70,12 +70,8 @@ auto ReadReservedIndex(SpanU8*, Context&) -> OptAt<Index>;
 auto ReadString(SpanU8*, Context&, string_view desc) -> OptAt<string_view>;
 auto ReadUtf8String(SpanU8*, Context&, string_view desc) -> OptAt<string_view>;
 
-enum class BulkImmediateKind {
-  Memory,
-  Table,
-};
-
-enum class AllowIndexType64 { No, Yes };
+enum class BulkImmediateKind { Memory, Table };
+enum class LimitsKind { Memory, Table };
 
 // Read functions for various binary types.
 auto Read(SpanU8*, Context&, Tag<ArrayType>) -> OptAt<ArrayType>;
@@ -120,7 +116,7 @@ auto Read(SpanU8*, Context&, Tag<InitImmediate>, BulkImmediateKind)
 auto Read(SpanU8*, Context&, Tag<Instruction>) -> OptAt<Instruction>;
 auto Read(SpanU8*, Context&, Tag<InstructionList>) -> OptAt<InstructionList>;
 auto Read(SpanU8*, Context&, Tag<LetImmediate>) -> OptAt<LetImmediate>;
-auto Read(SpanU8*, Context&, Tag<Limits>, AllowIndexType64) -> OptAt<Limits>;
+auto Read(SpanU8*, Context&, Tag<Limits>, LimitsKind) -> OptAt<Limits>;
 auto Read(SpanU8*, Context&, Tag<Locals>) -> OptAt<Locals>;
 auto Read(SpanU8*, Context&, Tag<MemArgImmediate>) -> OptAt<MemArgImmediate>;
 auto Read(SpanU8*, Context&, Tag<Memory>) -> OptAt<Memory>;

--- a/include/wasp/text/read.h
+++ b/include/wasp/text/read.h
@@ -94,11 +94,11 @@ auto ReadFunction(Tokenizer&, Context&) -> OptAt<Function>;
 
 // Section 4: Table
 
-enum class AllowIndexType { No, Yes };
+enum class LimitsKind { Memory, Table };
 enum class AllowFuncref { No, Yes };
 
 auto ReadIndexTypeOpt(Tokenizer&, Context&) -> OptAt<IndexType>;
-auto ReadLimits(Tokenizer&, Context&, AllowIndexType) -> OptAt<Limits>;
+auto ReadLimits(Tokenizer&, Context&, LimitsKind) -> OptAt<Limits>;
 auto ReadHeapType(Tokenizer&, Context&) -> OptAt<HeapType>;
 auto ReadRefType(Tokenizer&, Context&) -> OptAt<RefType>;
 auto ReadReferenceType(Tokenizer&, Context&, AllowFuncref = AllowFuncref::Yes)

--- a/test/text/read_test.cc
+++ b/test/text/read_test.cc
@@ -677,47 +677,52 @@ TEST_F(TextReadTest, OffsetOpt) {
 }
 
 TEST_F(TextReadTest, Limits) {
-  OK(ReadLimits, Limits{At{"1"_su8, 1u}}, "1"_su8, AllowIndexType::No);
+  OK(ReadLimits, Limits{At{"1"_su8, 1u}}, "1"_su8, LimitsKind::Memory);
   OK(ReadLimits, Limits{At{"1"_su8, 1u}, At{"0x11"_su8, 17u}}, "1 0x11"_su8,
-     AllowIndexType::No);
-  // TODO: Should only be allowed when threads feature is enabled.
+     LimitsKind::Memory);
+}
+
+TEST_F(TextReadTest, Limits_threads) {
+  context.features.enable_threads();
+
   OK(ReadLimits,
      Limits{At{"0"_su8, 0u}, At{"20"_su8, 20u}, At{"shared"_su8, Shared::Yes}},
-     "0 20 shared"_su8, AllowIndexType::No);
+     "0 20 shared"_su8, LimitsKind::Memory);
 }
 
 TEST_F(TextReadTest, Limits_memory64) {
   Fail(ReadLimits, {{0, "Expected a natural number, got NumericType"}},
-       "i32 1"_su8, AllowIndexType::Yes);
+       "i32 1"_su8, LimitsKind::Memory);
 
   context.features.enable_memory64();
 
   OK(ReadLimits,
      Limits{At{"1"_su8, 1u}, nullopt, Shared::No,
             At{"i32"_su8, IndexType::I32}},
-     "i32 1"_su8, AllowIndexType::Yes);
+     "i32 1"_su8, LimitsKind::Memory);
 
   OK(ReadLimits,
      Limits{At{"1"_su8, 1u}, At{"2"_su8, 2u}, Shared::No,
             At{"i32"_su8, IndexType::I32}},
-     "i32 1 2"_su8, AllowIndexType::Yes);
+     "i32 1 2"_su8, LimitsKind::Memory);
 
   OK(ReadLimits,
      Limits{At{"1"_su8, 1u}, nullopt, Shared::No,
             At{"i64"_su8, IndexType::I64}},
-     "i32 1"_su8, AllowIndexType::Yes);
+     "i32 1"_su8, LimitsKind::Memory);
 
   OK(ReadLimits,
      Limits{At{"1"_su8, 1u}, At{"2"_su8, 2u}, Shared::No,
             At{"i64"_su8, IndexType::I64}},
-     "i32 1 2"_su8, AllowIndexType::Yes);
+     "i32 1 2"_su8, LimitsKind::Memory);
 }
 
 TEST_F(TextReadTest, Limits_No64BitShared) {
+  context.features.enable_threads();
   context.features.enable_memory64();
 
   Fail(ReadLimits, {{8, "limits cannot be shared and have i64 index"}},
-       "i64 1 2 shared"_su8, AllowIndexType::Yes);
+       "i64 1 2 shared"_su8, LimitsKind::Memory);
 }
 
 TEST_F(TextReadTest, BlockImmediate) {


### PR DESCRIPTION
The shared flag was added in the `threads` proposal, so shouldn't be
parsed unless that proposal is enabled.