### PR TITLE
Allow reading field lists with packed types

### DIFF
--- a/src/text/read.cc
+++ b/src/text/read.cc
@@ -383,7 +383,7 @@ bool IsFieldTypeContents(Tokenizer& tokenizer) {
   auto token = tokenizer.Peek();
   return (token.type == TokenType::Lpar &&
           tokenizer.Peek(1).type == TokenType::Mut) ||
-         IsValueType(tokenizer);
+         IsValueType(tokenizer) || token.type == TokenType::PackedType;
 }
 
 auto ReadFieldTypeContents(Tokenizer& tokenizer, Context& context)

--- a/test/text/read_test.cc
+++ b/test/text/read_test.cc
@@ -538,6 +538,15 @@ TEST_F(TextReadTest, FieldTypeList) {
                    Mutability::Const}}},
      "(field i32)"_su8);
 
+  // Packed field
+  OK(ReadFieldTypeList,
+     FieldTypeList{
+         At{"i8"_su8,
+            FieldType{nullopt,
+                      At{"i8"_su8, StorageType{At{"i8"_su8, PackedType::I8}}},
+                      Mutability::Const}}},
+     "(field i8)"_su8);
+
   // Combined fields
   OK(ReadFieldTypeList,
      FieldTypeList{


### PR DESCRIPTION
Field lists were parsed correctly for value types (e.g. `(field i32)`),
but not for packed types (e.g. `(field i8)`)