### PR TITLE
Write `HeapKind` and `BlockType` as signed values

### DIFF
--- a/include/wasp/binary/write.h
+++ b/include/wasp/binary/write.h
@@ -104,7 +104,7 @@ Iterator Write(HeapType value, Iterator out) {
     return Write(encoding::HeapKind::Encode(value.heap_kind()), out);
   } else {
     assert(value.is_index());
-    return Write(value.index(), out);
+    return Write(static_cast<s32>(value.index()), out);
   }
 }
 
@@ -153,7 +153,7 @@ Iterator Write(BlockType value, Iterator out) {
     return Write(encoding::BlockType::Void, out);
   } else {
     assert(value.is_index());
-    return Write(value.index(), out);
+    return Write(static_cast<s32>(value.index()), out);
   }
 }
 

--- a/test/binary/write_test.cc
+++ b/test/binary/write_test.cc
@@ -64,6 +64,7 @@ TEST(BinaryWriteTest, BlockType_MVP) {
 
 TEST(BinaryWriteTest, BlockType_multi_value) {
   ExpectWrite("\x01"_su8, BlockType{Index{1}});
+  ExpectWrite("\xc0\x00"_su8, BlockType{Index{64}});
   ExpectWrite("\xc0\x03"_su8, BlockType{Index{448}});
 }
 
@@ -476,6 +477,7 @@ TEST(BinaryWriteTest, HeapType_function_references) {
   ExpectWrite("\x70"_su8, HT_Func);
   ExpectWrite("\x6f"_su8, HT_Extern);
   ExpectWrite("\x00"_su8, HT_0);
+  ExpectWrite("\xc0\x00"_su8, HeapType{At{"\xc0\x00"_su8, Index{64}}});
 }
 
 TEST(BinaryWriteTest, HeapType_gc) {


### PR DESCRIPTION
The heap and block type encodings both use signed values, where negative
values represent well-known values, and non-negative values are indexes
into the type section. This commit fixes a bug where the indexes were
written with LEB128 encoding (instead of SLEB128 encoding).

The difference is first noticeable at index 64, where the unsigned
encoding is `0x40`, but the unsigned encoding is `0xc0 0x00`.