### PR TITLE
Fix spec test failure in func.wast

### DIFF
--- a/src/text/resolve.cc
+++ b/src/text/resolve.cc
@@ -304,11 +304,10 @@ void Resolve(ResolveContext& context, FunctionTypeUse& function_type_use) {
     if (type_use->value().is_index()) {
       auto type_index = type_use->value().index();
       auto type_opt = context.function_type_map.Get(type_index);
-      // It's possible that this type use is invalid, but that's a validation
-      // error not a parse/resolve error. We'll only check that the type use and
-      // explicit function type match when the type use is valid.
+      bool has_explicit_params_or_results =
+          type->params.size() || type->results.size();
       if (type_opt) {
-        if (type->params.size() || type->results.size()) {
+        if (has_explicit_params_or_results) {
           // Explicit params/results, so check that they match.
           if (type != *type_opt) {
             context.errors.OnError(
@@ -319,6 +318,11 @@ void Resolve(ResolveContext& context, FunctionTypeUse& function_type_use) {
           // No params/results given, so populate them.
           type = *type_opt;
         }
+      } else if (has_explicit_params_or_results) {
+        // We can't compare the type index to the explicit params/results, so
+        // this must be considered a syntax error.
+        context.errors.OnError(type_use->loc(),
+                               concat("Invalid type index ", type_use));
       }
     }
   } else {
@@ -353,11 +357,10 @@ void Resolve(ResolveContext& context,
     if (type_use->value().is_index()) {
       auto type_index = type_use->value().index();
       auto type_opt = context.function_type_map.Get(type_index);
-      // It's possible that this type use is invalid, but that's a validation
-      // error not a parse/resolve error. We'll only check that the type use and
-      // explicit function type match when the type use is valid.
+      bool has_explicit_params_or_results =
+          type->params.size() || type->results.size();
       if (type_opt) {
-        if (type->params.size() || type->results.size()) {
+        if (has_explicit_params_or_results) {
           // Explicit params/results, so check that they match.
           if (type->params != type_opt->params ||
               type->results != type_opt->results) {
@@ -369,6 +372,11 @@ void Resolve(ResolveContext& context,
           // No params/results given, so populate them.
           type = ToBoundFunctionType(*type_opt);
         }
+      } else if (has_explicit_params_or_results) {
+        // We can't compare the type index to the explicit params/results, so
+        // this must be considered a syntax error.
+        context.errors.OnError(type_use->loc(),
+                               concat("Invalid type index ", type_use));
       }
     }
   } else {

--- a/test/text/resolve_test.cc
+++ b/test/text/resolve_test.cc
@@ -249,6 +249,14 @@ TEST_F(TextResolveTest, FunctionTypeUse_NoFunctionTypeInContext) {
   EXPECT_EQ((FunctionTypeUse{Var{Index{0}}, {}}), type_use);
 }
 
+TEST_F(TextResolveTest, FunctionTypeUse_IndexOOBWithExplicitParams) {
+  FunctionTypeUse function_type_use;
+  function_type_use.type_use = At{loc1, Var{Index{0}}};
+  function_type_use.type = At{FunctionType{{VT_I32}, {}}};
+  Resolve(context, function_type_use);
+  ExpectError(ErrorList{{loc1, "Invalid type index 0"}}, errors);
+}
+
 TEST_F(TextResolveTest, BoundValueType) {
   context.type_names.NewBound("$t"_sv);
   OK(BVT{nullopt, Resolved_VT_Ref0}, BVT{nullopt, VT_RefT});
@@ -276,6 +284,14 @@ TEST_F(TextResolveTest, BoundFunctionTypeUse_NoFunctionTypeInContext) {
   Resolve(context, type_use, type);
   EXPECT_EQ(Var{Index{0}}, type_use);
   EXPECT_EQ(At{BoundFunctionType{}}, type);
+}
+
+TEST_F(TextResolveTest, BoundFunctionType_IndexOOBWithExplicitParams) {
+  OptAt<Var> type_use = At{loc1, Var{Index{0}}};
+  At<BoundFunctionType> type =
+      At{BoundFunctionType{{BVT{nullopt, VT_I32}}, {}}};
+  Resolve(context, type_use, type);
+  ExpectError(ErrorList{{loc1, "Invalid type index 0"}}, errors);
 }
 
 TEST_F(TextResolveTest, BlockImmediate) {


### PR DESCRIPTION
The wasm text format allows the use of a function type to be specified
one of three ways:

```
;; 1. As an explicit type index or symbol
(type 0)

;; 2. As params and results
(param i32) (result i64)

;; 3. Both; an explicit type index, params and results
(type 0) (param i32) (result i64)
```

Options 2 and 3 are text format sugar, since the binary format always
encodes these as an explicit type index.

Option 3 needs to check that the type at that index matches the
explicitly given params and results. Normally checking whether an index
is in bounds is a validation step, not a syntax checking step. However,
in this case if the index is out of bounds, then the types cannot be
checked, so it must be a syntax error.

The only additional complication is that there are two different kinds
of function type uses, bound and unbound. Bound function type uses allow
for the explicit params to be named.

Bound function type uses are seen in function definiitions:

```
(func (type 0) (param $x i32) ...)
```

Unbound function type uses are seen in instructions like
`call_indirect`:

```
call_indirect (type 0) (param i32)
```

Wasp models these differently, so they need to be resolved differently
too.