### PR TITLE
Add ReadModule(), which reads full binary module

### DIFF
--- a/include/wasp/base/errors.h
+++ b/include/wasp/base/errors.h
@@ -29,6 +29,8 @@ class Errors {
   void PopContext();
   void OnError(Location loc, string_view message);
 
+  virtual bool HasError() const = 0;
+
  protected:
   virtual void HandlePushContext(Location loc, string_view desc) = 0;
   virtual void HandlePopContext() = 0;

--- a/include/wasp/base/errors_nop.h
+++ b/include/wasp/base/errors_nop.h
@@ -22,6 +22,9 @@
 namespace wasp {
 
 class ErrorsNop : public Errors {
+ public:
+  bool HasError() const override { return false; }
+
  protected:
   void HandlePushContext(Location loc, string_view desc) override {}
   void HandlePopContext() override {}

--- a/include/wasp/binary/lazy_module.h
+++ b/include/wasp/binary/lazy_module.h
@@ -37,7 +37,7 @@ class LazyModule {
   LazySequence<Section> sections;
 };
 
-LazyModule ReadModule(SpanU8 data, const Features&, Errors&);
+LazyModule ReadLazyModule(SpanU8 data, const Features&, Errors&);
 
 }  // namespace wasp::binary
 

--- a/include/wasp/binary/read.h
+++ b/include/wasp/binary/read.h
@@ -29,6 +29,10 @@ namespace wasp::binary {
 
 struct Context;
 
+// Read a full binary module eagerly (see ReadLazyModule to read lazily).
+auto ReadModule(SpanU8, Context&) -> optional<Module>;
+
+
 template <typename T>
 struct Tag {};
 

--- a/include/wasp/binary/visitor.h
+++ b/include/wasp/binary/visitor.h
@@ -217,13 +217,13 @@ inline Result Visit(LazyModule& module, Visitor& visitor) {
               {
                 for (const auto& code : sec.sequence) {
                   WASP_IF_OK(
-                      visitor.BeginCode(*code), {
+                      visitor.BeginCode(code), {
                         for (auto&& instr :
                              ReadExpression(*code->body, module.context)) {
                           WASP_CHECK(visitor.OnInstruction(instr));
                         }
                         EndCode(code->body->data.last(0), module.context);
-                        WASP_CHECK(visitor.EndCode(*code));
+                        WASP_CHECK(visitor.EndCode(code));
                       })
                 }
                 WASP_CHECK(visitor.EndCodeSection(sec));

--- a/src/binary/CMakeLists.txt
+++ b/src/binary/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(libwasp_binary
   name_section/sections.cc
   name_section/types.cc
   read.cc
+  read_module.cc
   sections.cc
   types.cc
 )

--- a/src/binary/lazy_module.cc
+++ b/src/binary/lazy_module.cc
@@ -36,7 +36,9 @@ LazyModule::LazyModule(SpanU8 data, const Features& features, Errors& errors)
       version{ReadBytesExpected(&data, kVersionSpan, context, "version")},
       sections{data, context} {}
 
-LazyModule ReadModule(SpanU8 data, const Features& features, Errors& errors) {
+LazyModule ReadLazyModule(SpanU8 data,
+                          const Features& features,
+                          Errors& errors) {
   return LazyModule{data, features, errors};
 }
 

--- a/src/binary/read.cc
+++ b/src/binary/read.cc
@@ -119,6 +119,7 @@ OptAt<SpanU8> ReadBytesExpected(SpanU8* data,
   if (actual && **actual != expected) {
     context.errors.OnError(actual->loc(), concat("Mismatch: expected ",
                                                  expected, ", got ", *actual));
+    return nullopt;
   }
   return actual;
 }

--- a/src/binary/read_module.cc
+++ b/src/binary/read_module.cc
@@ -1,0 +1,121 @@
+//
+// Copyright 2020 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "wasp/binary/read.h"
+
+#include "wasp/base/errors_context_guard.h"
+#include "wasp/binary/lazy_module.h"
+#include "wasp/binary/read/location_guard.h"
+#include "wasp/binary/read/macros.h"
+#include "wasp/binary/visitor.h"
+
+namespace wasp::binary {
+
+using visit::Result;
+
+struct EagerModuleVisitor : visit::Visitor {
+  explicit EagerModuleVisitor(Module& module) : module{module} {}
+
+  auto OnType(const At<DefinedType>& type) -> Result {
+    module.types.push_back(type);
+    return Result::Ok;
+  }
+
+  auto OnImport(const At<Import>& import) -> Result {
+    module.imports.push_back(import);
+    return Result::Ok;
+  }
+
+  auto OnFunction(const At<Function>& function) -> Result {
+    module.functions.push_back(function);
+    return Result::Ok;
+  }
+
+  auto OnTable(const At<Table>& table) -> Result {
+    module.tables.push_back(table);
+    return Result::Ok;
+  }
+
+  auto OnMemory(const At<Memory>& memory) -> Result {
+    module.memories.push_back(memory);
+    return Result::Ok;
+  }
+
+  auto OnGlobal(const At<Global>& global) -> Result {
+    module.globals.push_back(global);
+    return Result::Ok;
+  }
+
+  auto OnEvent(const At<Event>& event) -> Result {
+    module.events.push_back(event);
+    return Result::Ok;
+  }
+
+  auto OnExport(const At<Export>& export_) -> Result {
+    module.exports.push_back(export_);
+    return Result::Ok;
+  }
+
+  auto OnStart(const At<Start>& start) -> Result {
+    module.start = start;
+    return Result::Ok;
+  }
+
+  auto OnElement(const At<ElementSegment>& element_segment) -> Result {
+    module.element_segments.push_back(element_segment);
+    return Result::Ok;
+  }
+
+  auto OnDataCount(const At<DataCount>& data_count) -> Result {
+    module.data_count = data_count;
+    return Result::Ok;
+  }
+
+  auto BeginCode(const At<Code>& code) -> Result {
+    module.codes.push_back(At{code.loc(), UnpackedCode{code->locals, {}}});
+    return Result::Ok;
+  }
+
+  auto OnInstruction(const At<Instruction>& instruction) -> Result {
+    module.codes.back()->body.instructions.push_back(instruction);
+    return Result::Ok;
+  }
+
+  auto OnData(const At<DataSegment>& data_segment) -> Result {
+    module.data_segments.push_back(data_segment);
+    return Result::Ok;
+  }
+
+  Module& module;
+};
+
+auto ReadModule(SpanU8 data, Context& context) -> optional<Module> {
+  ErrorsContextGuard error_guard{context.errors, data, "module"};
+  LazyModule lazy_module{data, context.features, context.errors};
+  if (!(lazy_module.magic.has_value() && lazy_module.version.has_value())) {
+    return nullopt;
+  }
+
+  Module module;
+  EagerModuleVisitor visitor{module};
+  if (Visit(lazy_module, visitor) == Result::Fail ||
+      context.errors.HasError()) {
+    return nullopt;
+  }
+  return module;
+}
+
+}  // namespace wasp::binary

--- a/src/tools/binary_errors.h
+++ b/src/tools/binary_errors.h
@@ -34,7 +34,7 @@ class BinaryErrors : public Errors {
   explicit BinaryErrors(SpanU8 data);
   explicit BinaryErrors(string_view filename, SpanU8 data);
 
-  bool has_error() const { return !errors.empty(); }
+  bool HasError() const override { return !errors.empty(); }
   void PrintTo(std::ostream&);
 
  protected:

--- a/src/tools/callgraph.cc
+++ b/src/tools/callgraph.cc
@@ -131,7 +131,7 @@ int Main(span<const string_view> args) {
 Tool::Tool(SpanU8 data, Options options)
     : errors{data},
       options{options},
-      module{ReadModule(data, options.features, errors)} {}
+      module{ReadLazyModule(data, options.features, errors)} {}
 
 int Tool::Run() {
   DoPrepass();

--- a/src/tools/cfg.cc
+++ b/src/tools/cfg.cc
@@ -157,7 +157,7 @@ int Main(span<const string_view> args) {
 Tool::Tool(SpanU8 data, Options options)
     : errors{data},
       options{options},
-      module{ReadModule(data, options.features, errors)} {}
+      module{ReadLazyModule(data, options.features, errors)} {}
 
 int Tool::Run() {
   DoPrepass();

--- a/src/tools/dfg.cc
+++ b/src/tools/dfg.cc
@@ -205,7 +205,7 @@ int Main(span<const string_view> args) {
 Tool::Tool(SpanU8 data, Options options)
     : errors{data},
       options{options},
-      module{ReadModule(data, options.features, errors)} {}
+      module{ReadLazyModule(data, options.features, errors)} {}
 
 int Tool::Run() {
   DoPrepass();

--- a/src/tools/dump.cc
+++ b/src/tools/dump.cc
@@ -264,7 +264,7 @@ Tool::Tool(string_view filename, SpanU8 data, Options options)
       options{options},
       data{data},
       errors{data},
-      module{ReadModule(data, options.features, errors)} {}
+      module{ReadLazyModule(data, options.features, errors)} {}
 
 void Tool::Run() {
   if (!(module.magic && module.version)) {

--- a/src/tools/pattern.cc
+++ b/src/tools/pattern.cc
@@ -130,7 +130,7 @@ int Main(span<const string_view> args) {
 Tool::Tool(SpanU8 data, Options options)
     : errors{data},
       options{options},
-      module{ReadModule(data, options.features, errors)} {}
+      module{ReadLazyModule(data, options.features, errors)} {}
 
 int Tool::Run() {
   Visitor visitor{*this};

--- a/src/tools/text_errors.cc
+++ b/src/tools/text_errors.cc
@@ -30,7 +30,7 @@ TextErrors::TextErrors(string_view filename, SpanU8 data)
     : filename{filename}, data{data} {}
 
 void TextErrors::PrintTo(std::ostream& os) const {
-  if (has_error()) {
+  if (HasError()) {
     CalculateLineNumbers();
     for (const auto& error : errors) {
       os << ErrorToString(error);
@@ -38,7 +38,7 @@ void TextErrors::PrintTo(std::ostream& os) const {
   }
 }
 
-bool TextErrors::has_error() const {
+bool TextErrors::HasError() const {
   return !errors.empty();
 }
 

--- a/src/tools/text_errors.h
+++ b/src/tools/text_errors.h
@@ -36,7 +36,7 @@ class TextErrors : public Errors {
   explicit TextErrors(string_view filename, SpanU8 data);
 
   void PrintTo(std::ostream&) const;
-  bool has_error() const;
+  bool HasError() const override;
 
  protected:
   void HandlePushContext(SpanU8 pos, string_view desc) override;

--- a/src/tools/validate.cc
+++ b/src/tools/validate.cc
@@ -112,14 +112,14 @@ Tool::Tool(string_view filename, SpanU8 data, Options options)
       options{options},
       data{data},
       errors{data},
-      module{ReadModule(data, options.features, errors)},
+      module{ReadLazyModule(data, options.features, errors)},
       visitor{options.features, errors} {}
 
 bool Tool::Run() {
   if (module.magic && module.version) {
     visit::Visit(module, visitor);
   }
-  return !errors.has_error();
+  return !errors.HasError();
 }
 
 }  // namespace validate

--- a/src/tools/wat2wasm.cc
+++ b/src/tools/wat2wasm.cc
@@ -132,7 +132,7 @@ int Tool::Run() {
   Resolve(text_module, errors);
   Desugar(text_module);
 
-  if (errors.has_error()) {
+  if (errors.HasError()) {
     errors.PrintTo(std::cerr);
     return 1;
   }
@@ -144,7 +144,7 @@ int Tool::Run() {
     valid::Context validate_context{options.features, errors};
     Validate(validate_context, binary_module);
 
-    if (errors.has_error()) {
+    if (errors.HasError()) {
       errors.PrintTo(std::cerr);
       return 1;
     }

--- a/test/binary/CMakeLists.txt
+++ b/test/binary/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(wasp_binary_unittests
   lazy_sequence_test.cc
   read_test.cc
   read_linking_test.cc
+  read_module_test.cc
   visitor_test.cc
   write_test.cc
 )

--- a/test/binary/lazy_module_test.cc
+++ b/test/binary/lazy_module_test.cc
@@ -27,7 +27,7 @@ using namespace ::wasp::test;
 TEST(BinaryLazyModuleTest, Basic) {
   Features features;
   TestErrors errors;
-  auto module = ReadModule(
+  auto module = ReadLazyModule(
       "\0asm\x01\0\0\0"
       "\x01\x03\0\0\0"            // Invalid type section.
       "\x03\x05\0\0\0\0\0"        // Invalid function section.
@@ -70,7 +70,7 @@ TEST(BinaryLazyModuleTest, Basic) {
 TEST(BinaryLazyModuleTest, BadMagic) {
   TestErrors errors;
   auto data = "wasm\x01\0\0\0"_su8;
-  auto module = ReadModule(data, Features{}, errors);
+  auto module = ReadLazyModule(data, Features{}, errors);
   WASP_USE(module);
 
   ExpectError({{0, "magic"},
@@ -81,7 +81,7 @@ TEST(BinaryLazyModuleTest, BadMagic) {
 TEST(BinaryLazyModuleTest, Magic_PastEnd) {
   TestErrors errors;
   auto data = "\0as"_su8;
-  auto module = ReadModule(data, Features{}, errors);
+  auto module = ReadLazyModule(data, Features{}, errors);
   WASP_USE(module);
 
   // TODO(binji): This should produce better errors.
@@ -93,7 +93,7 @@ TEST(BinaryLazyModuleTest, Magic_PastEnd) {
 TEST(BinaryLazyModuleTest, BadVersion) {
   TestErrors errors;
   auto data = "\0asm\x02\0\0\0"_su8;
-  auto module = ReadModule(data, Features{}, errors);
+  auto module = ReadLazyModule(data, Features{}, errors);
   WASP_USE(module);
 
   ExpectError({{4, "version"},
@@ -104,7 +104,7 @@ TEST(BinaryLazyModuleTest, BadVersion) {
 TEST(BinaryLazyModuleTest, Version_PastEnd) {
   TestErrors errors;
   auto data = "\0asm\x01"_su8;
-  auto module = ReadModule(data, Features{}, errors);
+  auto module = ReadLazyModule(data, Features{}, errors);
   WASP_USE(module);
 
   ExpectError({{4, "version"}, {4, "Unable to read 4 bytes"}}, errors, data);

--- a/test/binary/lazy_module_utils_test.cc
+++ b/test/binary/lazy_module_utils_test.cc
@@ -46,7 +46,7 @@ SpanU8 GetModuleData() {
 TEST(BinaryLazyModuleUtilsTest, ForEachFunctionName) {
   Features features;
   TestErrors errors;
-  auto module = ReadModule(GetModuleData(), features, errors);
+  auto module = ReadLazyModule(GetModuleData(), features, errors);
 
   ForEachFunctionName(module, [](const std::pair<Index, string_view>& pair) {
     switch (pair.first) {
@@ -72,7 +72,7 @@ TEST(BinaryLazyModuleUtilsTest, ForEachFunctionName) {
 TEST(BinaryLazyModuleUtilsTest, CopyFunctionNames) {
   Features features;
   TestErrors errors;
-  auto module = ReadModule(GetModuleData(), features, errors);
+  auto module = ReadLazyModule(GetModuleData(), features, errors);
 
   using FunctionNameMap = std::map<Index, string_view>;
 
@@ -96,7 +96,7 @@ TEST(BinaryLazyModuleUtilsTest, GetImportCount) {
       "\0\x01x\x03\x7f\0"
       "\0\x01z\x01\x70\0\0"_su8;
 
-  auto module = ReadModule(data, features, errors);
+  auto module = ReadLazyModule(data, features, errors);
 
   EXPECT_EQ(1u, GetImportCount(module, ExternalKind::Function));
   EXPECT_EQ(1u, GetImportCount(module, ExternalKind::Global));

--- a/test/binary/read_module_test.cc
+++ b/test/binary/read_module_test.cc
@@ -1,0 +1,153 @@
+//
+// Copyright 2020 WebAssembly Community Group participants
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "wasp/binary/read.h"
+
+#include "gtest/gtest.h"
+#include "test/binary/constants.h"
+#include "test/binary/test_utils.h"
+#include "test/test_utils.h"
+#include "wasp/binary/read/context.h"
+
+using namespace ::wasp;
+using namespace ::wasp::binary;
+using namespace ::wasp::test;
+using namespace ::wasp::binary::test;
+
+class BinaryReadModuleTest : public ::testing::Test {
+ protected:
+  void OK(const Module& expected, SpanU8 data) {
+    auto actual = ReadModule(data, context);
+    ExpectNoErrors(errors);
+    ASSERT_TRUE(actual.has_value());
+    EXPECT_EQ(expected, actual.value());
+  }
+
+  void Fail(const ExpectedError& error, SpanU8 data) {
+    auto actual = ReadModule(data, context);
+    EXPECT_FALSE(actual.has_value());
+    ExpectError(error, errors, data);
+    errors.Clear();
+  }
+
+  TestErrors errors;
+  Context context{errors};
+};
+
+TEST_F(BinaryReadModuleTest, EmptyModule) {
+  OK(
+      Module{
+          // types
+          {},
+          // imports
+          {},
+          // functions
+          {},
+          // tables
+          {},
+          // memories
+          {},
+          // globals
+          {},
+          // events
+          {},
+          // exports
+          {},
+          // start
+          {},
+          // element_segments
+          {},
+          // data_count
+          {},
+          // codes
+          {},
+          // data_segments
+          {},
+      },
+      "\0asm\x01\0\0\0"_su8);
+}
+
+TEST_F(BinaryReadModuleTest, SimpleModule) {
+  OK(
+      Module{
+          // types
+          {At{"\x60\x00\x01\x7f"_su8,
+              DefinedType{At{"\x00\x01\x7f"_su8,
+                             FunctionType{{}, {At{"\x7f"_su8, VT_I32}}}}}}},
+          // imports
+          {},
+          // functions
+          {At{"\x00"_su8, Function{At{"\x00"_su8, Index{0}}}}},
+          // tables
+          {},
+          // memories
+          {},
+          // globals
+          {},
+          // events
+          {},
+          // exports
+          {},
+          // start
+          {},
+          // element_segments
+          {},
+          // data_count
+          {},
+          // codes
+          {At{"\x04\x00\x41\x2a\x0b"_su8,
+              UnpackedCode{
+                  {},
+                  UnpackedExpression{
+                      {At{"\x41\x2a"_su8,
+                          Instruction{At{"\x41"_su8, Opcode::I32Const},
+                                      At{"\x2a"_su8, s32{42}}}},
+                       At{"\x0b"_su8,
+                          Instruction{At{"\x0b"_su8, Opcode::End}}}}}}}},
+          // data_segments
+          {},
+      },
+      "\0asm\x01\0\0\0"
+      // type: (func (result i32))
+      "\x01\x05\x01\x60\x00\x01\x7f"
+      // func: (func (type 0))
+      "\x03\x02\x01\x00"
+      // code: (func (type 0) i32.const 42)
+      "\x0a\x06\x01\x04\x00\x41\x2a\x0b"_su8);
+}
+
+TEST_F(BinaryReadModuleTest, BadMagic) {
+  Fail({{0, "module"},
+        {0, "magic"},
+        {0,
+         "Mismatch: expected \"\\00\\61\\73\\6d\", got \"\\00\\41\\53\\4d\""}},
+       "\0ASM\x01\0\0\0"_su8);
+}
+
+TEST_F(BinaryReadModuleTest, BadVersion) {
+  Fail({{0, "module"},
+        {4, "version"},
+        {4,
+         "Mismatch: expected \"\\01\\00\\00\\00\", got \"\\02\\00\\00\\00\""}},
+       "\0asm\x02\0\0\0"_su8);
+}
+
+TEST_F(BinaryReadModuleTest, BadTypeSection) {
+  Fail({{0, "module"}, {10, "count"}, {10, "Unable to read u8"}},
+       "\0asm\x01\0\0\0"
+       "\x01\x00"_su8  // Empty type section.
+  );
+}

--- a/test/binary/visitor_test.cc
+++ b/test/binary/visitor_test.cc
@@ -117,7 +117,7 @@ class BinaryVisitorTest : public ::testing::Test {
 
   template <typename Visitor>
   visit::Result Visit(Visitor& visitor) {
-    LazyModule module = ReadModule(SpanU8{kTestModule}, features, errors);
+    LazyModule module = ReadLazyModule(SpanU8{kTestModule}, features, errors);
     return visit::Visit(module, visitor);
   }
 

--- a/test/run_spec_tests.cc
+++ b/test/run_spec_tests.cc
@@ -183,7 +183,7 @@ void Tool::Run() {
     Resolve(*script, errors);
   }
 
-  if (!script || errors.has_error()) {
+  if (!script || errors.HasError()) {
     errors.PrintTo(std::cerr);
     return;
   }
@@ -192,7 +192,7 @@ void Tool::Run() {
     OnCommand(command);
   }
 
-  if (errors.has_error()) {
+  if (errors.HasError()) {
     errors.PrintTo(std::cerr);
   }
 }
@@ -265,7 +265,7 @@ void Tool::OnAssertMalformedText(Location loc,
   if (script) {
     Resolve(*script, nested_errors);
   }
-  if (!nested_errors.has_error()) {
+  if (!nested_errors.HasError()) {
     errors.OnError(loc, "Expected malformed text module.");
   }
   if (s_verbose > 1) {
@@ -278,10 +278,10 @@ void Tool::OnAssertMalformedBinary(Location loc,
                                  const Buffer& buffer) {
   tools::BinaryErrors nested_errors{filename, buffer};
   binary::LazyModule module =
-      binary::ReadModule(buffer, features, nested_errors);
+      binary::ReadLazyModule(buffer, features, nested_errors);
   binary::visit::Visitor visitor;
   binary::visit::Visit(module, visitor);
-  if (!nested_errors.has_error()) {
+  if (!nested_errors.HasError()) {
     errors.OnError(loc, "Expected malformed binary module.");
   }
   if (s_verbose > 1) {
@@ -299,7 +299,7 @@ void Tool::OnAssertInvalid(Location loc, const text::Module& orig_text_module) {
   auto binary_module = convert::ToBinary(convert_context, text_module);
   valid::Context valid_context{features, nested_errors};
   bool result = Validate(valid_context, binary_module);
-  if (result || !nested_errors.has_error()) {
+  if (result || !nested_errors.HasError()) {
     errors.OnError(loc, "Expected invalid module.");
   }
   if (s_verbose > 1) {

--- a/test/test_utils.cc
+++ b/test/test_utils.cc
@@ -46,6 +46,10 @@ void TestErrors::Clear() {
   errors.clear();
 }
 
+bool TestErrors::HasError() const {
+  return !errors.empty();
+}
+
 void TestErrors::HandlePushContext(Location loc, string_view desc) {
   context_stack.push_back(Error{loc, std::string{desc}});
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -40,11 +40,12 @@ class TestErrors : public Errors {
   std::vector<ErrorList> errors;
 
   void Clear();
+  bool HasError() const override;
 
  protected:
-  void HandlePushContext(Location loc, string_view desc);
-  void HandlePopContext();
-  void HandleOnError(Location loc, string_view message);
+  void HandlePushContext(Location loc, string_view desc) override;
+  void HandlePopContext() override;
+  void HandleOnError(Location loc, string_view message) override;
 };
 
 void ExpectNoErrors(const TestErrors&);


### PR DESCRIPTION
Previously the only way to read a module was lazily, section by section.
That's still the most efficient way to read a module, but if you know
that you'll need the full contents anyway, it's nicer to have a function
that reads all the sections into their components directly.

This change renames `ReadModule` to `ReadLazyModule`, and introduces a
new `ReadModule` function that reads into the existing `binary::Module`
struct.

This required a few other changes:

* The binary visitor was accidentally removing some of the locations;

* Some module reading errors are only logged to the `wasp::Errors`
  struct, so you can't easily know whether reading the module succeeded
  unless you query that struct. The `TextErrors` and `BinaryErrors`
  derived classes already had this ability (`has_error()`), so now it is a
  virtual method on `wasp::Errors` too (renamed to `HasError()`)