### PR TITLE
Fix a few function text writing bugs

### DIFF
--- a/test/text/write_test.cc
+++ b/test/text/write_test.cc
@@ -697,6 +697,21 @@ TEST(TextWriteTest, FunctionInlineImport) {
                        InlineExportList{InlineExport{Text{"\"m\""_sv, 1}}}});
 }
 
+TEST(TextWriteTest, Function_OmitFinalEnd) {
+  ExpectWrite(
+      "(func\n  nop\n  nop)"_sv,
+      Function{{}, {}, InstructionList{I{O::Nop}, I{O::Nop}, I{O::End}}, {}});
+}
+
+
+TEST(TextWriteTest, Function_DontOverDedent) {
+  // Multiple ends like this is syntatically malformed, but still should be
+  // writable.
+  ExpectWrite(
+      "(func\n  end\n  end)"_sv,
+      Function{{}, {}, InstructionList{I{O::End}, I{O::End}, I{O::End}}, {}});
+}
+
 TEST(TextWriteTest, ElementExpressionList) {
   ExpectWrite("(ref.null) (ref.func 0)"_sv,
               ElementExpressionList{


### PR DESCRIPTION
The `end` instruction dedents the written output, but was assuming that
the instruction sequence was always well-formed. Now the `Dedent()`
function clamps to prevent underflow.

Also, the text format was assuming that a function's instruction
sequence would not have an `end` instruction, but the binary->text
conversion was including it. This means that an empty binary function
would be printed as `(func end)` in the text format, which is incorrect.
Now the text writing omits the final `end` instruction in the sequence,
if there is one.