### PR TITLE
Add DataCount only if bulk-memory is enabled

### DIFF
--- a/include/wasp/convert/to_binary.h
+++ b/include/wasp/convert/to_binary.h
@@ -23,6 +23,7 @@
 
 #include "wasp/base/at.h"
 #include "wasp/base/buffer.h"
+#include "wasp/base/features.h"
 #include "wasp/base/optional.h"
 #include "wasp/binary/types.h"
 #include "wasp/text/types.h"
@@ -30,8 +31,13 @@
 namespace wasp::convert {
 
 struct Context {
+  explicit Context() = default;
+  explicit Context(const Features&);
+
   string_view Add(std::string);
   SpanU8 Add(Buffer);
+
+  Features features;
 
   // TODO: The buffers need to have stable pointers (for use by string_view or
   // span), so for now they are all std::unique_ptr<T>. This could be optimized

--- a/src/convert/to_binary.cc
+++ b/src/convert/to_binary.cc
@@ -23,6 +23,8 @@
 
 namespace wasp::convert {
 
+Context::Context(const Features& features) : features{features} {}
+
 string_view Context::Add(std::string str) {
   strings.push_back(std::make_unique<std::string>(str));
   return string_view{*strings.back()};
@@ -860,8 +862,10 @@ auto ToBinary(Context& context, const At<text::Module>& value)
 
       case text::ModuleItemKind::DataSegment:
         result.data_segments.push_back(ToBinary(context, item.data_segment()));
-        result.data_count =
-            binary::DataCount{Index(result.data_segments.size())};
+        if (context.features.bulk_memory_enabled()) {
+          result.data_count =
+              binary::DataCount{Index(result.data_segments.size())};
+        }
         break;
 
       case text::ModuleItemKind::Event:

--- a/src/tools/wat2wasm.cc
+++ b/src/tools/wat2wasm.cc
@@ -137,7 +137,7 @@ int Tool::Run() {
     return 1;
   }
 
-  convert::Context convert_context;
+  convert::Context convert_context{options.features};
   auto binary_module = convert::ToBinary(convert_context, text_module);
 
   if (options.validate) {


### PR DESCRIPTION
When converting from text to binary, we should only add a DataCount
section if the bulk-memory feature flag is enabled. This requires adding
a `Feature` object to the conversion context.