### PR TITLE
Rename Context -> *Ctx [NFC]

### DIFF
--- a/include/wasp/binary/lazy_expression.h
+++ b/include/wasp/binary/lazy_expression.h
@@ -23,13 +23,13 @@
 
 namespace wasp::binary {
 
-struct Context;
+struct ReadCtx;
 
 /// ---
 using LazyExpression = LazySequence<Instruction>;
 
-LazyExpression ReadExpression(SpanU8, Context&);
-LazyExpression ReadExpression(Expression, Context&);
+LazyExpression ReadExpression(SpanU8, ReadCtx&);
+LazyExpression ReadExpression(Expression, ReadCtx&);
 
 }  // namespace wasp
 

--- a/include/wasp/binary/lazy_module.h
+++ b/include/wasp/binary/lazy_module.h
@@ -31,7 +31,7 @@ class LazyModule {
   explicit LazyModule(SpanU8, const Features&, Errors&);
 
   SpanU8 data;
-  Context context;
+  ReadCtx ctx;
   optional<SpanU8> magic;
   optional<SpanU8> version;
   LazySequence<Section> sections;

--- a/include/wasp/binary/lazy_module_utils.h
+++ b/include/wasp/binary/lazy_module_utils.h
@@ -29,7 +29,7 @@ class Errors;
 
 namespace binary {
 
-struct Context;
+struct ReadCtx;
 
 using IndexNamePair = std::pair<Index, string_view>;
 

--- a/include/wasp/binary/lazy_section.h
+++ b/include/wasp/binary/lazy_section.h
@@ -21,24 +21,24 @@
 #include "wasp/base/span.h"
 #include "wasp/binary/lazy_sequence.h"
 #include "wasp/binary/read.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 
 namespace wasp::binary {
 
-struct Context;
+struct ReadCtx;
 
 template <typename T>
 class LazySection {
  public:
-  explicit LazySection(SpanU8, string_view name, Context&);
+  explicit LazySection(SpanU8, string_view name, ReadCtx&);
 
   OptAt<Index> count;
   LazySequence<T> sequence;
 };
 
 template <typename T>
-LazySection<T>::LazySection(SpanU8 data, string_view name, Context& context)
-    : count{ReadCount(&data, context)}, sequence{data, count, name, context} {}
+LazySection<T>::LazySection(SpanU8 data, string_view name, ReadCtx& ctx)
+    : count{ReadCount(&data, ctx)}, sequence{data, count, name, ctx} {}
 
 }  // namespace wasp::binary
 

--- a/include/wasp/binary/lazy_sequence-inl.h
+++ b/include/wasp/binary/lazy_sequence-inl.h
@@ -26,7 +26,7 @@ void LazySequence<T>::NotifyRead(const u8* pos, bool ok) {
       count_++;
     } else if (expected_count_ && count_ != *expected_count_) {
       // Reached the end, but there was a mismatch.
-      LazySequenceBase::OnCountError(context_.errors,
+      LazySequenceBase::OnCountError(ctx_.errors,
                                      MakeSpan(last_pos_, data_.end()), name_,
                                      *expected_count_, count_);
     }
@@ -50,7 +50,7 @@ auto LazySequenceIterator<Sequence>::operator++() -> LazySequenceIterator& {
     sequence_->NotifyRead(pos, false);
     clear();
   } else {
-    value_ = Read<typename value_type::value_type>(&data_, sequence_->context_);
+    value_ = Read<typename value_type::value_type>(&data_, sequence_->ctx_);
     sequence_->NotifyRead(pos, !!value_);
     if (!value_) {
       clear();

--- a/include/wasp/binary/lazy_sequence.h
+++ b/include/wasp/binary/lazy_sequence.h
@@ -24,7 +24,7 @@
 #include "wasp/base/span.h"
 #include "wasp/base/string_view.h"
 #include "wasp/base/types.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 
 namespace wasp {
 
@@ -32,7 +32,7 @@ class Errors;
 
 namespace binary {
 
-struct Context;
+struct ReadCtx;
 
 template <typename Sequence>
 class LazySequenceIterator;
@@ -60,17 +60,13 @@ class LazySequence : public LazySequenceBase {
   using iterator = LazySequenceIterator<LazySequence>;
   using const_iterator = LazySequenceIterator<LazySequence>;
 
-  explicit LazySequence(SpanU8 data, Context& context)
-      : data_{data}, context_{context} {}
+  explicit LazySequence(SpanU8 data, ReadCtx& ctx) : data_{data}, ctx_{ctx} {}
 
   explicit LazySequence(SpanU8 data,
                         optional<Index> expected_count,
                         string_view name,
-                        Context& context)
-      : data_{data},
-        context_{context},
-        name_{name},
-        expected_count_{expected_count} {}
+                        ReadCtx& ctx)
+      : data_{data}, ctx_{ctx}, name_{name}, expected_count_{expected_count} {}
 
   iterator begin() { return iterator{this, data_}; }
   iterator end() { return iterator{this, SpanU8{}}; }
@@ -86,7 +82,7 @@ class LazySequence : public LazySequenceBase {
   void NotifyRead(const u8*, bool);
 
   SpanU8 data_;
-  Context& context_;
+  ReadCtx& ctx_;
 
   // Check for errors when there is an expected count.
   string_view name_;

--- a/include/wasp/binary/linking_section/read.h
+++ b/include/wasp/binary/linking_section/read.h
@@ -22,19 +22,19 @@
 
 namespace wasp::binary {
 
-struct Context;
+struct ReadCtx;
 
-auto Read(SpanU8*, Context&, Tag<Comdat>) -> OptAt<Comdat>;
-auto Read(SpanU8*, Context&, Tag<ComdatSymbol>) -> OptAt<ComdatSymbol>;
-auto Read(SpanU8*, Context&, Tag<ComdatSymbolKind>) -> OptAt<ComdatSymbolKind>;
-auto Read(SpanU8*, Context&, Tag<InitFunction>) -> OptAt<InitFunction>;
-auto Read(SpanU8*, Context&, Tag<LinkingSubsection>) -> OptAt<LinkingSubsection>;
-auto Read(SpanU8*, Context&, Tag<LinkingSubsectionId>) -> OptAt<LinkingSubsectionId>;
-auto Read(SpanU8*, Context&, Tag<RelocationEntry>) -> OptAt<RelocationEntry>;
-auto Read(SpanU8*, Context&, Tag<RelocationType>) -> OptAt<RelocationType>;
-auto Read(SpanU8*, Context&, Tag<SegmentInfo>) -> OptAt<SegmentInfo>;
-auto Read(SpanU8*, Context&, Tag<SymbolInfo>) -> OptAt<SymbolInfo>;
-auto Read(SpanU8*, Context&, Tag<SymbolInfoKind>) -> OptAt<SymbolInfoKind>;
+auto Read(SpanU8*, ReadCtx&, Tag<Comdat>) -> OptAt<Comdat>;
+auto Read(SpanU8*, ReadCtx&, Tag<ComdatSymbol>) -> OptAt<ComdatSymbol>;
+auto Read(SpanU8*, ReadCtx&, Tag<ComdatSymbolKind>) -> OptAt<ComdatSymbolKind>;
+auto Read(SpanU8*, ReadCtx&, Tag<InitFunction>) -> OptAt<InitFunction>;
+auto Read(SpanU8*, ReadCtx&, Tag<LinkingSubsection>) -> OptAt<LinkingSubsection>;
+auto Read(SpanU8*, ReadCtx&, Tag<LinkingSubsectionId>) -> OptAt<LinkingSubsectionId>;
+auto Read(SpanU8*, ReadCtx&, Tag<RelocationEntry>) -> OptAt<RelocationEntry>;
+auto Read(SpanU8*, ReadCtx&, Tag<RelocationType>) -> OptAt<RelocationType>;
+auto Read(SpanU8*, ReadCtx&, Tag<SegmentInfo>) -> OptAt<SegmentInfo>;
+auto Read(SpanU8*, ReadCtx&, Tag<SymbolInfo>) -> OptAt<SymbolInfo>;
+auto Read(SpanU8*, ReadCtx&, Tag<SymbolInfoKind>) -> OptAt<SymbolInfoKind>;
 
 }  // namespace wasp::binary
 

--- a/include/wasp/binary/linking_section/sections.h
+++ b/include/wasp/binary/linking_section/sections.h
@@ -27,7 +27,7 @@
 namespace wasp::binary {
 
 struct RelocationSection {
-  explicit RelocationSection(SpanU8, Context&);
+  explicit RelocationSection(SpanU8, ReadCtx&);
 
   SpanU8 data;
   optional<Index> section_index;
@@ -36,7 +36,7 @@ struct RelocationSection {
 };
 
 struct LinkingSection {
-  explicit LinkingSection(SpanU8, Context&);
+  explicit LinkingSection(SpanU8, ReadCtx&);
 
   SpanU8 data;
   optional<u32> version;
@@ -48,26 +48,26 @@ using LazyInitFunctionsSubsection = LazySection<InitFunction>;
 using LazyComdatSubsection = LazySection<Comdat>;
 using LazySymbolTableSubsection = LazySection<SymbolInfo>;
 
-auto ReadRelocationSection(SpanU8 data, Context&) -> RelocationSection;
-auto ReadRelocationSection(CustomSection sec, Context&) -> RelocationSection;
+auto ReadRelocationSection(SpanU8 data, ReadCtx&) -> RelocationSection;
+auto ReadRelocationSection(CustomSection sec, ReadCtx&) -> RelocationSection;
 
-auto ReadLinkingSection(SpanU8, Context&) -> LinkingSection;
-auto ReadLinkingSection(CustomSection, Context&) -> LinkingSection;
+auto ReadLinkingSection(SpanU8, ReadCtx&) -> LinkingSection;
+auto ReadLinkingSection(CustomSection, ReadCtx&) -> LinkingSection;
 
-auto ReadSegmentInfoSubsection(SpanU8, Context&) -> LazySegmentInfoSubsection;
-auto ReadSegmentInfoSubsection(LinkingSubsection, Context&)
+auto ReadSegmentInfoSubsection(SpanU8, ReadCtx&) -> LazySegmentInfoSubsection;
+auto ReadSegmentInfoSubsection(LinkingSubsection, ReadCtx&)
     -> LazySegmentInfoSubsection;
 
-auto ReadInitFunctionsSubsection(SpanU8, Context&)
+auto ReadInitFunctionsSubsection(SpanU8, ReadCtx&)
     -> LazyInitFunctionsSubsection;
-auto ReadInitFunctionsSubsection(LinkingSubsection, Context&)
+auto ReadInitFunctionsSubsection(LinkingSubsection, ReadCtx&)
     -> LazyInitFunctionsSubsection;
 
-auto ReadComdatSubsection(SpanU8, Context&) -> LazyComdatSubsection;
-auto ReadComdatSubsection(LinkingSubsection, Context&) -> LazyComdatSubsection;
+auto ReadComdatSubsection(SpanU8, ReadCtx&) -> LazyComdatSubsection;
+auto ReadComdatSubsection(LinkingSubsection, ReadCtx&) -> LazyComdatSubsection;
 
-auto ReadSymbolTableSubsection(SpanU8, Context&) -> LazySymbolTableSubsection;
-auto ReadSymbolTableSubsection(LinkingSubsection, Context&)
+auto ReadSymbolTableSubsection(SpanU8, ReadCtx&) -> LazySymbolTableSubsection;
+auto ReadSymbolTableSubsection(LinkingSubsection, ReadCtx&)
     -> LazySymbolTableSubsection;
 
 }  // namespace wasp::binary

--- a/include/wasp/binary/name_section/read.h
+++ b/include/wasp/binary/name_section/read.h
@@ -22,13 +22,13 @@
 
 namespace wasp::binary {
 
-struct Context;
+struct ReadCtx;
 
-auto Read(SpanU8*, Context&, Tag<IndirectNameAssoc>)
+auto Read(SpanU8*, ReadCtx&, Tag<IndirectNameAssoc>)
     -> OptAt<IndirectNameAssoc>;
-auto Read(SpanU8*, Context&, Tag<NameAssoc>) -> OptAt<NameAssoc>;
-auto Read(SpanU8*, Context&, Tag<NameSubsection>) -> OptAt<NameSubsection>;
-auto Read(SpanU8*, Context&, Tag<NameSubsectionId>) -> OptAt<NameSubsectionId>;
+auto Read(SpanU8*, ReadCtx&, Tag<NameAssoc>) -> OptAt<NameAssoc>;
+auto Read(SpanU8*, ReadCtx&, Tag<NameSubsection>) -> OptAt<NameSubsection>;
+auto Read(SpanU8*, ReadCtx&, Tag<NameSubsectionId>) -> OptAt<NameSubsectionId>;
 
 }  // namespace wasp::binary
 

--- a/include/wasp/binary/name_section/sections.h
+++ b/include/wasp/binary/name_section/sections.h
@@ -32,19 +32,19 @@ using ModuleNameSubsection = optional<string_view>;
 using LazyFunctionNamesSubsection = LazySection<NameAssoc>;
 using LazyLocalNamesSubsection = LazySection<IndirectNameAssoc>;
 
-auto ReadNameSection(SpanU8, Context&) -> LazyNameSection;
-auto ReadNameSection(CustomSection, Context&) -> LazyNameSection;
+auto ReadNameSection(SpanU8, ReadCtx&) -> LazyNameSection;
+auto ReadNameSection(CustomSection, ReadCtx&) -> LazyNameSection;
 
-auto ReadModuleNameSubsection(SpanU8, Context&) -> ModuleNameSubsection;
-auto ReadModuleNameSubsection(NameSubsection, Context&) -> ModuleNameSubsection;
+auto ReadModuleNameSubsection(SpanU8, ReadCtx&) -> ModuleNameSubsection;
+auto ReadModuleNameSubsection(NameSubsection, ReadCtx&) -> ModuleNameSubsection;
 
-auto ReadFunctionNamesSubsection(SpanU8, Context&)
+auto ReadFunctionNamesSubsection(SpanU8, ReadCtx&)
     -> LazyFunctionNamesSubsection;
-auto ReadFunctionNamesSubsection(NameSubsection, Context&)
+auto ReadFunctionNamesSubsection(NameSubsection, ReadCtx&)
     -> LazyFunctionNamesSubsection;
 
-auto ReadLocalNamesSubsection(SpanU8, Context&) -> LazyLocalNamesSubsection;
-auto ReadLocalNamesSubsection(NameSubsection, Context&)
+auto ReadLocalNamesSubsection(SpanU8, ReadCtx&) -> LazyLocalNamesSubsection;
+auto ReadLocalNamesSubsection(NameSubsection, ReadCtx&)
     -> LazyLocalNamesSubsection;
 
 }  // namespace wasp::binary

--- a/include/wasp/binary/read.h
+++ b/include/wasp/binary/read.h
@@ -27,10 +27,10 @@
 
 namespace wasp::binary {
 
-struct Context;
+struct ReadCtx;
 
 // Read a full binary module eagerly (see ReadLazyModule to read lazily).
-auto ReadModule(SpanU8, Context&) -> optional<Module>;
+auto ReadModule(SpanU8, ReadCtx&) -> optional<Module>;
 
 
 template <typename T>
@@ -38,118 +38,118 @@ struct Tag {};
 
 // Generic Read function.
 template <typename T, typename... Args>
-auto Read(SpanU8* data, Context& context, Args&&... args) -> OptAt<T> {
-  return Read(data, context, Tag<T>{}, std::forward<Args>(args)...);
+auto Read(SpanU8* data, ReadCtx& ctx, Args&&... args) -> OptAt<T> {
+  return Read(data, ctx, Tag<T>{}, std::forward<Args>(args)...);
 }
 
 // Read functions that return SpanU8.
-auto ReadBytes(SpanU8* data, span_extent_t N, Context&) -> OptAt<SpanU8>;
+auto ReadBytes(SpanU8* data, span_extent_t N, ReadCtx&) -> OptAt<SpanU8>;
 auto ReadBytesExpected(SpanU8* data,
                        SpanU8 expected,
-                       Context&,
+                       ReadCtx&,
                        string_view desc) -> OptAt<SpanU8>;
 
 // Read a byte without advancing the span.
-auto PeekU8(SpanU8*, Context&) -> OptAt<u8>;
+auto PeekU8(SpanU8*, ReadCtx&) -> OptAt<u8>;
 
 // Functions to read a length/count. The difference is only in the error word
 // used. Both ReadCount and ReadLength forward to ReadCheckLength.
-auto ReadCount(SpanU8*, Context&) -> OptAt<Index>;
-auto ReadLength(SpanU8*, Context&) -> OptAt<Index>;
+auto ReadCount(SpanU8*, ReadCtx&) -> OptAt<Index>;
+auto ReadLength(SpanU8*, ReadCtx&) -> OptAt<Index>;
 auto ReadCheckLength(SpanU8*,
-                     Context&,
+                     ReadCtx&,
                      string_view context_name,
                      string_view error_name) -> OptAt<Index>;
 
 // Identical to reading a u32.
-auto ReadIndex(SpanU8*, Context&, string_view desc) -> OptAt<Index>;
+auto ReadIndex(SpanU8*, ReadCtx&, string_view desc) -> OptAt<Index>;
 
 // Read a single byte that must be a 0. ReadReservedIndex casts the resulting
 // value to an Index.
-auto ReadReserved(SpanU8*, Context&) -> OptAt<u8>;
-auto ReadReservedIndex(SpanU8*, Context&) -> OptAt<Index>;
+auto ReadReserved(SpanU8*, ReadCtx&) -> OptAt<u8>;
+auto ReadReservedIndex(SpanU8*, ReadCtx&) -> OptAt<Index>;
 
 // ReadString reads a string as a collection of bytes. ReadUtf8String requires
 // that the string is utf-8 encoded.
-auto ReadString(SpanU8*, Context&, string_view desc) -> OptAt<string_view>;
-auto ReadUtf8String(SpanU8*, Context&, string_view desc) -> OptAt<string_view>;
+auto ReadString(SpanU8*, ReadCtx&, string_view desc) -> OptAt<string_view>;
+auto ReadUtf8String(SpanU8*, ReadCtx&, string_view desc) -> OptAt<string_view>;
 
 enum class BulkImmediateKind { Memory, Table };
 enum class LimitsKind { Memory, Table };
 
 // Read functions for various binary types.
-auto Read(SpanU8*, Context&, Tag<ArrayType>) -> OptAt<ArrayType>;
-auto Read(SpanU8*, Context&, Tag<BlockType>) -> OptAt<BlockType>;
-auto Read(SpanU8*, Context&, Tag<BrOnCastImmediate>)
+auto Read(SpanU8*, ReadCtx&, Tag<ArrayType>) -> OptAt<ArrayType>;
+auto Read(SpanU8*, ReadCtx&, Tag<BlockType>) -> OptAt<BlockType>;
+auto Read(SpanU8*, ReadCtx&, Tag<BrOnCastImmediate>)
     -> OptAt<BrOnCastImmediate>;
-auto Read(SpanU8*, Context&, Tag<BrOnExnImmediate>) -> OptAt<BrOnExnImmediate>;
-auto Read(SpanU8*, Context&, Tag<BrTableImmediate>) -> OptAt<BrTableImmediate>;
-auto Read(SpanU8*, Context&, Tag<CallIndirectImmediate>)
+auto Read(SpanU8*, ReadCtx&, Tag<BrOnExnImmediate>) -> OptAt<BrOnExnImmediate>;
+auto Read(SpanU8*, ReadCtx&, Tag<BrTableImmediate>) -> OptAt<BrTableImmediate>;
+auto Read(SpanU8*, ReadCtx&, Tag<CallIndirectImmediate>)
     -> OptAt<CallIndirectImmediate>;
-auto Read(SpanU8*, Context&, Tag<Code>) -> OptAt<Code>;
-auto Read(SpanU8*, Context&, Tag<ConstantExpression>)
+auto Read(SpanU8*, ReadCtx&, Tag<Code>) -> OptAt<Code>;
+auto Read(SpanU8*, ReadCtx&, Tag<ConstantExpression>)
     -> OptAt<ConstantExpression>;
-auto Read(SpanU8*, Context&, Tag<CopyImmediate>, BulkImmediateKind)
+auto Read(SpanU8*, ReadCtx&, Tag<CopyImmediate>, BulkImmediateKind)
     -> OptAt<CopyImmediate>;
-auto Read(SpanU8*, Context&, Tag<DataCount>) -> OptAt<DataCount>;
-auto Read(SpanU8*, Context&, Tag<DataSegment>) -> OptAt<DataSegment>;
-auto Read(SpanU8*, Context&, Tag<DefinedType>) -> OptAt<DefinedType>;
-auto Read(SpanU8*, Context&, Tag<ElementExpression>)
+auto Read(SpanU8*, ReadCtx&, Tag<DataCount>) -> OptAt<DataCount>;
+auto Read(SpanU8*, ReadCtx&, Tag<DataSegment>) -> OptAt<DataSegment>;
+auto Read(SpanU8*, ReadCtx&, Tag<DefinedType>) -> OptAt<DefinedType>;
+auto Read(SpanU8*, ReadCtx&, Tag<ElementExpression>)
     -> OptAt<ElementExpression>;
-auto Read(SpanU8*, Context&, Tag<ElementSegment>) -> OptAt<ElementSegment>;
-auto Read(SpanU8*, Context&, Tag<EventAttribute>) -> OptAt<EventAttribute>;
-auto Read(SpanU8*, Context&, Tag<Event>) -> OptAt<Event>;
-auto Read(SpanU8*, Context&, Tag<EventType>) -> OptAt<EventType>;
-auto Read(SpanU8*, Context&, Tag<Export>) -> OptAt<Export>;
-auto Read(SpanU8*, Context&, Tag<ExternalKind>) -> OptAt<ExternalKind>;
-auto Read(SpanU8*, Context&, Tag<f32>) -> OptAt<f32>;
-auto Read(SpanU8*, Context&, Tag<f64>) -> OptAt<f64>;
-auto Read(SpanU8*, Context&, Tag<FieldType>) -> OptAt<FieldType>;
-auto Read(SpanU8*, Context&, Tag<FuncBindImmediate>)
+auto Read(SpanU8*, ReadCtx&, Tag<ElementSegment>) -> OptAt<ElementSegment>;
+auto Read(SpanU8*, ReadCtx&, Tag<EventAttribute>) -> OptAt<EventAttribute>;
+auto Read(SpanU8*, ReadCtx&, Tag<Event>) -> OptAt<Event>;
+auto Read(SpanU8*, ReadCtx&, Tag<EventType>) -> OptAt<EventType>;
+auto Read(SpanU8*, ReadCtx&, Tag<Export>) -> OptAt<Export>;
+auto Read(SpanU8*, ReadCtx&, Tag<ExternalKind>) -> OptAt<ExternalKind>;
+auto Read(SpanU8*, ReadCtx&, Tag<f32>) -> OptAt<f32>;
+auto Read(SpanU8*, ReadCtx&, Tag<f64>) -> OptAt<f64>;
+auto Read(SpanU8*, ReadCtx&, Tag<FieldType>) -> OptAt<FieldType>;
+auto Read(SpanU8*, ReadCtx&, Tag<FuncBindImmediate>)
     -> OptAt<FuncBindImmediate>;
-auto Read(SpanU8*, Context&, Tag<Function>) -> OptAt<Function>;
-auto Read(SpanU8*, Context&, Tag<FunctionType>) -> OptAt<FunctionType>;
-auto Read(SpanU8*, Context&, Tag<Global>) -> OptAt<Global>;
-auto Read(SpanU8*, Context&, Tag<GlobalType>) -> OptAt<GlobalType>;
-auto Read(SpanU8*, Context&, Tag<HeapType>) -> OptAt<HeapType>;
-auto Read(SpanU8*, Context&, Tag<HeapType2Immediate>)
+auto Read(SpanU8*, ReadCtx&, Tag<Function>) -> OptAt<Function>;
+auto Read(SpanU8*, ReadCtx&, Tag<FunctionType>) -> OptAt<FunctionType>;
+auto Read(SpanU8*, ReadCtx&, Tag<Global>) -> OptAt<Global>;
+auto Read(SpanU8*, ReadCtx&, Tag<GlobalType>) -> OptAt<GlobalType>;
+auto Read(SpanU8*, ReadCtx&, Tag<HeapType>) -> OptAt<HeapType>;
+auto Read(SpanU8*, ReadCtx&, Tag<HeapType2Immediate>)
     -> OptAt<HeapType2Immediate>;
-auto Read(SpanU8*, Context&, Tag<Import>) -> OptAt<Import>;
-auto Read(SpanU8*, Context&, Tag<InitImmediate>, BulkImmediateKind)
+auto Read(SpanU8*, ReadCtx&, Tag<Import>) -> OptAt<Import>;
+auto Read(SpanU8*, ReadCtx&, Tag<InitImmediate>, BulkImmediateKind)
     -> OptAt<InitImmediate>;
-auto Read(SpanU8*, Context&, Tag<Instruction>) -> OptAt<Instruction>;
-auto Read(SpanU8*, Context&, Tag<InstructionList>) -> OptAt<InstructionList>;
-auto Read(SpanU8*, Context&, Tag<LetImmediate>) -> OptAt<LetImmediate>;
-auto Read(SpanU8*, Context&, Tag<Limits>, LimitsKind) -> OptAt<Limits>;
-auto Read(SpanU8*, Context&, Tag<Locals>) -> OptAt<Locals>;
-auto Read(SpanU8*, Context&, Tag<MemArgImmediate>) -> OptAt<MemArgImmediate>;
-auto Read(SpanU8*, Context&, Tag<Memory>) -> OptAt<Memory>;
-auto Read(SpanU8*, Context&, Tag<MemoryType>) -> OptAt<MemoryType>;
-auto Read(SpanU8*, Context&, Tag<Mutability>) -> OptAt<Mutability>;
-auto Read(SpanU8*, Context&, Tag<Opcode>) -> OptAt<Opcode>;
-auto Read(SpanU8*, Context&, Tag<s32>) -> OptAt<s32>;
-auto Read(SpanU8*, Context&, Tag<s64>) -> OptAt<s64>;
-auto Read(SpanU8*, Context&, Tag<RefType>) -> OptAt<RefType>;
-auto Read(SpanU8*, Context&, Tag<ReferenceType>) -> OptAt<ReferenceType>;
-auto Read(SpanU8*, Context&, Tag<Rtt>) -> OptAt<Rtt>;
-auto Read(SpanU8*, Context&, Tag<RttSubImmediate>) -> OptAt<RttSubImmediate>;
-auto Read(SpanU8*, Context&, Tag<SectionId>) -> OptAt<SectionId>;
-auto Read(SpanU8*, Context&, Tag<Section>) -> OptAt<Section>;
-auto Read(SpanU8*, Context&, Tag<ShuffleImmediate>) -> OptAt<ShuffleImmediate>;
-auto Read(SpanU8*, Context&, Tag<Start>) -> OptAt<Start>;
-auto Read(SpanU8*, Context&, Tag<StorageType>) -> OptAt<StorageType>;
-auto Read(SpanU8*, Context&, Tag<StructType>) -> OptAt<StructType>;
-auto Read(SpanU8*, Context&, Tag<StructFieldImmediate>)
+auto Read(SpanU8*, ReadCtx&, Tag<Instruction>) -> OptAt<Instruction>;
+auto Read(SpanU8*, ReadCtx&, Tag<InstructionList>) -> OptAt<InstructionList>;
+auto Read(SpanU8*, ReadCtx&, Tag<LetImmediate>) -> OptAt<LetImmediate>;
+auto Read(SpanU8*, ReadCtx&, Tag<Limits>, LimitsKind) -> OptAt<Limits>;
+auto Read(SpanU8*, ReadCtx&, Tag<Locals>) -> OptAt<Locals>;
+auto Read(SpanU8*, ReadCtx&, Tag<MemArgImmediate>) -> OptAt<MemArgImmediate>;
+auto Read(SpanU8*, ReadCtx&, Tag<Memory>) -> OptAt<Memory>;
+auto Read(SpanU8*, ReadCtx&, Tag<MemoryType>) -> OptAt<MemoryType>;
+auto Read(SpanU8*, ReadCtx&, Tag<Mutability>) -> OptAt<Mutability>;
+auto Read(SpanU8*, ReadCtx&, Tag<Opcode>) -> OptAt<Opcode>;
+auto Read(SpanU8*, ReadCtx&, Tag<s32>) -> OptAt<s32>;
+auto Read(SpanU8*, ReadCtx&, Tag<s64>) -> OptAt<s64>;
+auto Read(SpanU8*, ReadCtx&, Tag<RefType>) -> OptAt<RefType>;
+auto Read(SpanU8*, ReadCtx&, Tag<ReferenceType>) -> OptAt<ReferenceType>;
+auto Read(SpanU8*, ReadCtx&, Tag<Rtt>) -> OptAt<Rtt>;
+auto Read(SpanU8*, ReadCtx&, Tag<RttSubImmediate>) -> OptAt<RttSubImmediate>;
+auto Read(SpanU8*, ReadCtx&, Tag<SectionId>) -> OptAt<SectionId>;
+auto Read(SpanU8*, ReadCtx&, Tag<Section>) -> OptAt<Section>;
+auto Read(SpanU8*, ReadCtx&, Tag<ShuffleImmediate>) -> OptAt<ShuffleImmediate>;
+auto Read(SpanU8*, ReadCtx&, Tag<Start>) -> OptAt<Start>;
+auto Read(SpanU8*, ReadCtx&, Tag<StorageType>) -> OptAt<StorageType>;
+auto Read(SpanU8*, ReadCtx&, Tag<StructType>) -> OptAt<StructType>;
+auto Read(SpanU8*, ReadCtx&, Tag<StructFieldImmediate>)
     -> OptAt<StructFieldImmediate>;
-auto Read(SpanU8*, Context&, Tag<Table>) -> OptAt<Table>;
-auto Read(SpanU8*, Context&, Tag<TableType>) -> OptAt<TableType>;
-auto Read(SpanU8*, Context&, Tag<u32>) -> OptAt<u32>;
-auto Read(SpanU8*, Context&, Tag<u8>) -> OptAt<u8>;
-auto Read(SpanU8*, Context&, Tag<v128>) -> OptAt<v128>;
-auto Read(SpanU8*, Context&, Tag<ValueType>) -> OptAt<ValueType>;
+auto Read(SpanU8*, ReadCtx&, Tag<Table>) -> OptAt<Table>;
+auto Read(SpanU8*, ReadCtx&, Tag<TableType>) -> OptAt<TableType>;
+auto Read(SpanU8*, ReadCtx&, Tag<u32>) -> OptAt<u32>;
+auto Read(SpanU8*, ReadCtx&, Tag<u8>) -> OptAt<u8>;
+auto Read(SpanU8*, ReadCtx&, Tag<v128>) -> OptAt<v128>;
+auto Read(SpanU8*, ReadCtx&, Tag<ValueType>) -> OptAt<ValueType>;
 
-bool EndCode(SpanU8, Context&);
-bool EndModule(SpanU8, Context&);
+bool EndCode(SpanU8, ReadCtx&);
+bool EndModule(SpanU8, ReadCtx&);
 
 }  // namespace wasp::binary
 

--- a/include/wasp/binary/read/macros.h
+++ b/include/wasp/binary/read/macros.h
@@ -29,27 +29,27 @@
   }                              \
   auto var = *opt_##var /* No semicolon. */
 
-#define WASP_TRY_READ_CONTEXT(var, call, desc)         \
-  ErrorsContextGuard guard_##var(context.errors, *data, desc); \
-  WASP_TRY_READ(var, call);                            \
+#define WASP_TRY_READ_CONTEXT(var, call, desc)             \
+  ErrorsContextGuard guard_##var(ctx.errors, *data, desc); \
+  WASP_TRY_READ(var, call);                                \
   guard_##var.PopContext() /* No semicolon. */
 
-#define WASP_TRY_DECODE(out_var, in_var_at, Type, name)               \
-  auto out_var##opt = encoding::Type::Decode(in_var_at);              \
-  if (!out_var##opt) {                                                \
-    context.errors.OnError(in_var_at.loc(),                           \
-                           concat("Unknown " name ": ", *in_var_at)); \
-    return nullopt;                                                   \
-  }                                                                   \
-  auto out_var = At{in_var_at.loc(), *out_var##opt} /* No semicolon. */
+#define WASP_TRY_DECODE(out_var, in_var_at, Type, name)           \
+  auto out_var##opt = encoding::Type::Decode(in_var_at);          \
+  if (!out_var##opt) {                                            \
+    ctx.errors.OnError(in_var_at.loc(),                           \
+                       concat("Unknown " name ": ", *in_var_at)); \
+    return nullopt;                                               \
+  }                                                               \
+  auto out_var = At { in_var_at.loc(), *out_var##opt } /* No semicolon. */
 
 #define WASP_TRY_DECODE_FEATURES(out_var, in_var_at, Type, name, features) \
   auto out_var##opt = encoding::Type::Decode(in_var_at, features);         \
   if (!out_var##opt) {                                                     \
-    context.errors.OnError(in_var_at.loc(),                                \
-                           concat("Unknown " name ": ", *in_var_at));      \
+    ctx.errors.OnError(in_var_at.loc(),                                    \
+                       concat("Unknown " name ": ", *in_var_at));          \
     return nullopt;                                                        \
   }                                                                        \
-  auto out_var = At{in_var_at.loc(), *out_var##opt} /* No semicolon. */
+  auto out_var = At { in_var_at.loc(), *out_var##opt } /* No semicolon. */
 
 #endif  // WASP_BINARY_MACROS_H_

--- a/include/wasp/binary/read/read_ctx.h
+++ b/include/wasp/binary/read/read_ctx.h
@@ -27,9 +27,9 @@ class Errors;
 
 namespace binary {
 
-struct Context {
-  explicit Context(Errors&);
-  explicit Context(const Features&, Errors&);
+struct ReadCtx {
+  explicit ReadCtx(Errors&);
+  explicit ReadCtx(const Features&, Errors&);
 
   void Reset();
 

--- a/include/wasp/binary/read/read_vector.h
+++ b/include/wasp/binary/read/read_vector.h
@@ -25,21 +25,21 @@
 #include "wasp/base/string_view.h"
 #include "wasp/base/types.h"
 #include "wasp/binary/read.h"
-#include "wasp/binary/read/context.h"
 #include "wasp/binary/read/macros.h"
+#include "wasp/binary/read/read_ctx.h"
 
 namespace wasp::binary {
 
 template <typename T>
 optional<std::vector<At<T>>> ReadVector(SpanU8* data,
-                                        Context& context,
+                                        ReadCtx& ctx,
                                         string_view desc) {
-  ErrorsContextGuard guard{context.errors, *data, desc};
+  ErrorsContextGuard guard{ctx.errors, *data, desc};
   std::vector<At<T>> result;
-  WASP_TRY_READ(len, ReadCount(data, context));
+  WASP_TRY_READ(len, ReadCount(data, ctx));
   result.reserve(len);
   for (u32 i = 0; i < len; ++i) {
-    WASP_TRY_READ(elt, Read<T>(data, context));
+    WASP_TRY_READ(elt, Read<T>(data, ctx));
     result.emplace_back(std::move(elt));
   }
   return result;

--- a/include/wasp/binary/sections.h
+++ b/include/wasp/binary/sections.h
@@ -43,38 +43,38 @@ using DataCountSection = OptAt<DataCount>;
 using LazyCodeSection = LazySection<Code>;
 using LazyDataSection = LazySection<DataSegment>;
 
-auto ReadTypeSection(SpanU8, Context&) -> LazyTypeSection;
-auto ReadTypeSection(KnownSection, Context&) -> LazyTypeSection;
-auto ReadImportSection(SpanU8, Context&) -> LazyImportSection;
-auto ReadImportSection(KnownSection, Context&) -> LazyImportSection;
-auto ReadFunctionSection(SpanU8, Context&) -> LazyFunctionSection;
-auto ReadFunctionSection(KnownSection, Context&) -> LazyFunctionSection;
-auto ReadTableSection(SpanU8, Context&) -> LazyTableSection;
-auto ReadTableSection(KnownSection, Context&) -> LazyTableSection;
-auto ReadMemorySection(SpanU8, Context&) -> LazyMemorySection;
-auto ReadMemorySection(KnownSection, Context&) -> LazyMemorySection;
-auto ReadGlobalSection(SpanU8, Context&) -> LazyGlobalSection;
-auto ReadGlobalSection(KnownSection, Context&) -> LazyGlobalSection;
-auto ReadEventSection(SpanU8, Context&) -> LazyEventSection;
-auto ReadEventSection(KnownSection, Context&) -> LazyEventSection;
-auto ReadExportSection(SpanU8, Context&) -> LazyExportSection;
-auto ReadExportSection(KnownSection, Context&) -> LazyExportSection;
-auto ReadElementSection(SpanU8, Context&) -> LazyElementSection;
-auto ReadElementSection(KnownSection, Context&) -> LazyElementSection;
-auto ReadDataCountSection(SpanU8, Context&) -> DataCountSection;
-auto ReadDataCountSection(KnownSection, Context&) -> DataCountSection;
-auto ReadCodeSection(SpanU8, Context&) -> LazyCodeSection;
-auto ReadCodeSection(KnownSection, Context&) -> LazyCodeSection;
-auto ReadDataSection(SpanU8, Context&) -> LazyDataSection;
-auto ReadDataSection(KnownSection, Context&) -> LazyDataSection;
+auto ReadTypeSection(SpanU8, ReadCtx&) -> LazyTypeSection;
+auto ReadTypeSection(KnownSection, ReadCtx&) -> LazyTypeSection;
+auto ReadImportSection(SpanU8, ReadCtx&) -> LazyImportSection;
+auto ReadImportSection(KnownSection, ReadCtx&) -> LazyImportSection;
+auto ReadFunctionSection(SpanU8, ReadCtx&) -> LazyFunctionSection;
+auto ReadFunctionSection(KnownSection, ReadCtx&) -> LazyFunctionSection;
+auto ReadTableSection(SpanU8, ReadCtx&) -> LazyTableSection;
+auto ReadTableSection(KnownSection, ReadCtx&) -> LazyTableSection;
+auto ReadMemorySection(SpanU8, ReadCtx&) -> LazyMemorySection;
+auto ReadMemorySection(KnownSection, ReadCtx&) -> LazyMemorySection;
+auto ReadGlobalSection(SpanU8, ReadCtx&) -> LazyGlobalSection;
+auto ReadGlobalSection(KnownSection, ReadCtx&) -> LazyGlobalSection;
+auto ReadEventSection(SpanU8, ReadCtx&) -> LazyEventSection;
+auto ReadEventSection(KnownSection, ReadCtx&) -> LazyEventSection;
+auto ReadExportSection(SpanU8, ReadCtx&) -> LazyExportSection;
+auto ReadExportSection(KnownSection, ReadCtx&) -> LazyExportSection;
+auto ReadElementSection(SpanU8, ReadCtx&) -> LazyElementSection;
+auto ReadElementSection(KnownSection, ReadCtx&) -> LazyElementSection;
+auto ReadDataCountSection(SpanU8, ReadCtx&) -> DataCountSection;
+auto ReadDataCountSection(KnownSection, ReadCtx&) -> DataCountSection;
+auto ReadCodeSection(SpanU8, ReadCtx&) -> LazyCodeSection;
+auto ReadCodeSection(KnownSection, ReadCtx&) -> LazyCodeSection;
+auto ReadDataSection(SpanU8, ReadCtx&) -> LazyDataSection;
+auto ReadDataSection(KnownSection, ReadCtx&) -> LazyDataSection;
 
-inline StartSection ReadStartSection(SpanU8 data, Context& context) {
+inline StartSection ReadStartSection(SpanU8 data, ReadCtx& ctx) {
   SpanU8 copy = data;
-  return Read<Start>(&copy, context);
+  return Read<Start>(&copy, ctx);
 }
 
-inline StartSection ReadStartSection(KnownSection sec, Context& context) {
-  return ReadStartSection(sec.data, context);
+inline StartSection ReadStartSection(KnownSection sec, ReadCtx& ctx) {
+  return ReadStartSection(sec.data, ctx);
 }
 
 }  // namespace binary

--- a/include/wasp/convert/to_binary.h
+++ b/include/wasp/convert/to_binary.h
@@ -30,9 +30,9 @@
 
 namespace wasp::convert {
 
-struct Context {
-  explicit Context() = default;
-  explicit Context(const Features&);
+struct BinCtx {
+  explicit BinCtx() = default;
+  explicit BinCtx(const Features&);
 
   string_view Add(std::string);
   SpanU8 Add(Buffer);
@@ -48,92 +48,92 @@ struct Context {
 };
 
 // Helpers.
-auto ToBinary(Context&, const At<text::HeapType>&) -> At<binary::HeapType>;
-auto ToBinary(Context&, const At<text::RefType>&) -> At<binary::RefType>;
-auto ToBinary(Context&, const At<text::ReferenceType>&) -> At<binary::ReferenceType>;
-auto ToBinary(Context&, const At<text::Rtt>&) -> At<binary::Rtt>;
-auto ToBinary(Context&, const At<text::ValueType>&) -> At<binary::ValueType>;
-auto ToBinary(Context&, const text::ValueTypeList&) -> binary::ValueTypeList;
-auto ToBinary(Context&, const At<text::StorageType>&) -> At<binary::StorageType>;
-auto ToBinary(Context&, const At<text::Text>&) -> At<string_view>;
-auto ToBinary(Context&, const At<text::Var>&) -> At<Index>;
-auto ToBinary(Context&, const OptAt<text::Var>&) -> At<Index>;
-auto ToBinary(Context&, const OptAt<text::Var>&, Index default_index) -> At<Index>;
-auto ToBinary(Context&, const text::VarList&) -> binary::IndexList;
-auto ToBinary(Context&, const At<text::FunctionType>&) -> At<binary::FunctionType>;
+auto ToBinary(BinCtx&, const At<text::HeapType>&) -> At<binary::HeapType>;
+auto ToBinary(BinCtx&, const At<text::RefType>&) -> At<binary::RefType>;
+auto ToBinary(BinCtx&, const At<text::ReferenceType>&) -> At<binary::ReferenceType>;
+auto ToBinary(BinCtx&, const At<text::Rtt>&) -> At<binary::Rtt>;
+auto ToBinary(BinCtx&, const At<text::ValueType>&) -> At<binary::ValueType>;
+auto ToBinary(BinCtx&, const text::ValueTypeList&) -> binary::ValueTypeList;
+auto ToBinary(BinCtx&, const At<text::StorageType>&) -> At<binary::StorageType>;
+auto ToBinary(BinCtx&, const At<text::Text>&) -> At<string_view>;
+auto ToBinary(BinCtx&, const At<text::Var>&) -> At<Index>;
+auto ToBinary(BinCtx&, const OptAt<text::Var>&) -> At<Index>;
+auto ToBinary(BinCtx&, const OptAt<text::Var>&, Index default_index) -> At<Index>;
+auto ToBinary(BinCtx&, const text::VarList&) -> binary::IndexList;
+auto ToBinary(BinCtx&, const At<text::FunctionType>&) -> At<binary::FunctionType>;
 
 // Section 1: Type
-auto ToBinary(Context&, const text::BoundValueTypeList&) -> binary::ValueTypeList;
-auto ToBinary(Context&, const At<text::FieldType>&) -> At<binary::FieldType>;
-auto ToBinary(Context&, const text::FieldTypeList&) -> binary::FieldTypeList;
-auto ToBinary(Context&, const At<text::StructType>&) -> At<binary::StructType>;
-auto ToBinary(Context&, const At<text::ArrayType>&) -> At<binary::ArrayType>;
-auto ToBinary(Context&, const At<text::DefinedType>&) -> At<binary::DefinedType>;
+auto ToBinary(BinCtx&, const text::BoundValueTypeList&) -> binary::ValueTypeList;
+auto ToBinary(BinCtx&, const At<text::FieldType>&) -> At<binary::FieldType>;
+auto ToBinary(BinCtx&, const text::FieldTypeList&) -> binary::FieldTypeList;
+auto ToBinary(BinCtx&, const At<text::StructType>&) -> At<binary::StructType>;
+auto ToBinary(BinCtx&, const At<text::ArrayType>&) -> At<binary::ArrayType>;
+auto ToBinary(BinCtx&, const At<text::DefinedType>&) -> At<binary::DefinedType>;
 
 // Section 2: Import
-auto ToBinary(Context&, const At<text::Import>&) -> At<binary::Import>;
+auto ToBinary(BinCtx&, const At<text::Import>&) -> At<binary::Import>;
 
 // Section 3: Function
-auto ToBinary(Context&, const At<text::Function>&) -> OptAt<binary::Function>;
+auto ToBinary(BinCtx&, const At<text::Function>&) -> OptAt<binary::Function>;
 
 // Section 4: Table
-auto ToBinary(Context&, const At<text::TableType>&) -> At<binary::TableType>;
-auto ToBinary(Context&, const At<text::Table>&) -> OptAt<binary::Table>;
+auto ToBinary(BinCtx&, const At<text::TableType>&) -> At<binary::TableType>;
+auto ToBinary(BinCtx&, const At<text::Table>&) -> OptAt<binary::Table>;
 
 // Section 5: Memory
-auto ToBinary(Context&, const At<text::Memory>&) -> OptAt<binary::Memory>;
+auto ToBinary(BinCtx&, const At<text::Memory>&) -> OptAt<binary::Memory>;
 
 // Section 6: Global
-auto ToBinary(Context&, const At<text::ConstantExpression>&) -> At<binary::ConstantExpression>;
-auto ToBinary(Context&, const At<text::GlobalType>&) -> At<binary::GlobalType>;
-auto ToBinary(Context&, const At<text::Global>&) -> OptAt<binary::Global>;
+auto ToBinary(BinCtx&, const At<text::ConstantExpression>&) -> At<binary::ConstantExpression>;
+auto ToBinary(BinCtx&, const At<text::GlobalType>&) -> At<binary::GlobalType>;
+auto ToBinary(BinCtx&, const At<text::Global>&) -> OptAt<binary::Global>;
 
 // Section 7: Export
-auto ToBinary(Context&, const At<text::Export>&) -> At<binary::Export>;
+auto ToBinary(BinCtx&, const At<text::Export>&) -> At<binary::Export>;
 
 // Section 8: Start
-auto ToBinary(Context&, const At<text::Start>&) -> At<binary::Start>;
+auto ToBinary(BinCtx&, const At<text::Start>&) -> At<binary::Start>;
 
 // Section 9: Elem
-auto ToBinary(Context&, const At<text::ElementExpression>&) -> At<binary::ElementExpression>;
-auto ToBinary(Context&, const text::ElementExpressionList&) -> binary::ElementExpressionList;
-auto ToBinary(Context&, const text::ElementList&) -> binary::ElementList;
-auto ToBinary(Context&, const At<text::ElementSegment>&) -> At<binary::ElementSegment>;
+auto ToBinary(BinCtx&, const At<text::ElementExpression>&) -> At<binary::ElementExpression>;
+auto ToBinary(BinCtx&, const text::ElementExpressionList&) -> binary::ElementExpressionList;
+auto ToBinary(BinCtx&, const text::ElementList&) -> binary::ElementList;
+auto ToBinary(BinCtx&, const At<text::ElementSegment>&) -> At<binary::ElementSegment>;
 
 // Section 10: Code
-auto ToBinary(Context&, const At<text::BlockImmediate>&) -> At<binary::BlockType>;
-auto ToBinary(Context&, const At<text::BrOnCastImmediate>&) -> At<binary::BrOnCastImmediate>;
-auto ToBinary(Context&, const At<text::BrOnExnImmediate>&) -> At<binary::BrOnExnImmediate>;
-auto ToBinary(Context&, const At<text::BrTableImmediate>&) -> At<binary::BrTableImmediate>;
-auto ToBinary(Context&, const At<text::CallIndirectImmediate>&) -> At<binary::CallIndirectImmediate>;
-auto ToBinary(Context&, const At<text::CopyImmediate>&) -> At<binary::CopyImmediate>;
-auto ToBinary(Context&, const At<text::FuncBindImmediate>&) -> At<binary::FuncBindImmediate>;
-auto ToBinary(Context&, const At<text::HeapType2Immediate>&) -> At<binary::HeapType2Immediate>;
-auto ToBinary(Context&, const At<text::InitImmediate>&) -> At<binary::InitImmediate>;
-auto ToBinary(Context&, const At<text::LetImmediate>&) -> At<binary::LetImmediate>;
-auto ToBinary(Context&, const At<text::MemArgImmediate>&, u32 natural_align) -> At<binary::MemArgImmediate>;
-auto ToBinary(Context&, const At<text::RttSubImmediate>&) -> At<binary::RttSubImmediate>;
-auto ToBinary(Context&, const At<text::StructFieldImmediate>&) -> At<binary::StructFieldImmediate>;
-auto ToBinary(Context&, const At<text::Instruction>&) -> At<binary::Instruction>;
-auto ToBinary(Context&, const text::InstructionList&) -> binary::InstructionList;
+auto ToBinary(BinCtx&, const At<text::BlockImmediate>&) -> At<binary::BlockType>;
+auto ToBinary(BinCtx&, const At<text::BrOnCastImmediate>&) -> At<binary::BrOnCastImmediate>;
+auto ToBinary(BinCtx&, const At<text::BrOnExnImmediate>&) -> At<binary::BrOnExnImmediate>;
+auto ToBinary(BinCtx&, const At<text::BrTableImmediate>&) -> At<binary::BrTableImmediate>;
+auto ToBinary(BinCtx&, const At<text::CallIndirectImmediate>&) -> At<binary::CallIndirectImmediate>;
+auto ToBinary(BinCtx&, const At<text::CopyImmediate>&) -> At<binary::CopyImmediate>;
+auto ToBinary(BinCtx&, const At<text::FuncBindImmediate>&) -> At<binary::FuncBindImmediate>;
+auto ToBinary(BinCtx&, const At<text::HeapType2Immediate>&) -> At<binary::HeapType2Immediate>;
+auto ToBinary(BinCtx&, const At<text::InitImmediate>&) -> At<binary::InitImmediate>;
+auto ToBinary(BinCtx&, const At<text::LetImmediate>&) -> At<binary::LetImmediate>;
+auto ToBinary(BinCtx&, const At<text::MemArgImmediate>&, u32 natural_align) -> At<binary::MemArgImmediate>;
+auto ToBinary(BinCtx&, const At<text::RttSubImmediate>&) -> At<binary::RttSubImmediate>;
+auto ToBinary(BinCtx&, const At<text::StructFieldImmediate>&) -> At<binary::StructFieldImmediate>;
+auto ToBinary(BinCtx&, const At<text::Instruction>&) -> At<binary::Instruction>;
+auto ToBinary(BinCtx&, const text::InstructionList&) -> binary::InstructionList;
 
 // TODO: Create text::Expression instead of using text::InstructionList here.
-auto ToBinaryUnpackedExpression(Context&, const At<text::InstructionList>&) -> At<binary::UnpackedExpression>;
-auto ToBinaryLocalsList(Context&, const At<text::BoundValueTypeList>&) -> At<binary::LocalsList>;
-auto ToBinaryCode(Context&, const At<text::Function>&) -> OptAt<binary::UnpackedCode>;
+auto ToBinaryUnpackedExpression(BinCtx&, const At<text::InstructionList>&) -> At<binary::UnpackedExpression>;
+auto ToBinaryLocalsList(BinCtx&, const At<text::BoundValueTypeList>&) -> At<binary::LocalsList>;
+auto ToBinaryCode(BinCtx&, const At<text::Function>&) -> OptAt<binary::UnpackedCode>;
 
 // Section 11: Data
-auto ToBinary(Context&, const At<text::DataItemList>&) -> SpanU8;
-auto ToBinary(Context&, const At<text::DataSegment>&) -> At<binary::DataSegment>;
+auto ToBinary(BinCtx&, const At<text::DataItemList>&) -> SpanU8;
+auto ToBinary(BinCtx&, const At<text::DataSegment>&) -> At<binary::DataSegment>;
 
 // Section 12: DataCount
 
 // Section 13: Event
-auto ToBinary(Context&, const At<text::EventType>&) -> At<binary::EventType>;
-auto ToBinary(Context&, const At<text::Event>&) -> OptAt<binary::Event>;
+auto ToBinary(BinCtx&, const At<text::EventType>&) -> At<binary::EventType>;
+auto ToBinary(BinCtx&, const At<text::Event>&) -> OptAt<binary::Event>;
 
 // Module
-auto ToBinary(Context&, const At<text::Module>&) -> At<binary::Module>;
+auto ToBinary(BinCtx&, const At<text::Module>&) -> At<binary::Module>;
 
 }  // namespace wasp::convert
 

--- a/include/wasp/convert/to_text.h
+++ b/include/wasp/convert/to_text.h
@@ -30,8 +30,7 @@
 
 namespace wasp::convert {
 
-// TODO: Rename
-struct TextContext {
+struct TextCtx {
   text::Text Add(string_view);
 
   // TODO: The buffers need to have stable pointers (for use by string_view or
@@ -42,91 +41,91 @@ struct TextContext {
 };
 
 // Helpers.
-auto ToText(TextContext&, const At<binary::HeapType>&) -> At<text::HeapType>;
-auto ToText(TextContext&, const At<binary::RefType>&) -> At<text::RefType>;
-auto ToText(TextContext&, const At<binary::ReferenceType>&) -> At<text::ReferenceType>;
-auto ToText(TextContext&, const At<binary::Rtt>&) -> At<text::Rtt>;
-auto ToText(TextContext&, const At<binary::ValueType>&) -> At<text::ValueType>;
-auto ToText(TextContext&, const binary::ValueTypeList&) -> text::ValueTypeList;
-auto ToTextBound(TextContext&, const binary::ValueTypeList&) -> At<text::BoundValueTypeList>;
-auto ToText(TextContext&, const At<binary::StorageType>&) -> At<text::StorageType>;
-auto ToText(TextContext&, const At<string_view>&) -> At<text::Text>;
-auto ToText(TextContext&, const At<Index>&) -> At<text::Var>;
-auto ToText(TextContext&, const OptAt<Index>&) -> OptAt<text::Var>;
-auto ToText(TextContext&, const binary::IndexList&) -> text::VarList;
-auto ToText(TextContext&, const At<binary::FunctionType>&) -> At<text::FunctionType>;
+auto ToText(TextCtx&, const At<binary::HeapType>&) -> At<text::HeapType>;
+auto ToText(TextCtx&, const At<binary::RefType>&) -> At<text::RefType>;
+auto ToText(TextCtx&, const At<binary::ReferenceType>&) -> At<text::ReferenceType>;
+auto ToText(TextCtx&, const At<binary::Rtt>&) -> At<text::Rtt>;
+auto ToText(TextCtx&, const At<binary::ValueType>&) -> At<text::ValueType>;
+auto ToText(TextCtx&, const binary::ValueTypeList&) -> text::ValueTypeList;
+auto ToTextBound(TextCtx&, const binary::ValueTypeList&) -> At<text::BoundValueTypeList>;
+auto ToText(TextCtx&, const At<binary::StorageType>&) -> At<text::StorageType>;
+auto ToText(TextCtx&, const At<string_view>&) -> At<text::Text>;
+auto ToText(TextCtx&, const At<Index>&) -> At<text::Var>;
+auto ToText(TextCtx&, const OptAt<Index>&) -> OptAt<text::Var>;
+auto ToText(TextCtx&, const binary::IndexList&) -> text::VarList;
+auto ToText(TextCtx&, const At<binary::FunctionType>&) -> At<text::FunctionType>;
 
 // Section 1: Type
-auto ToTextBound(TextContext&, const At<binary::FunctionType>&) -> At<text::BoundFunctionType>;
-auto ToText(TextContext&, const At<binary::FieldType>&) -> At<text::FieldType>;
-auto ToText(TextContext&, const binary::FieldTypeList&) -> text::FieldTypeList;
-auto ToText(TextContext&, const At<binary::StructType>&) -> At<text::StructType>;
-auto ToText(TextContext&, const At<binary::ArrayType>&) -> At<text::ArrayType>;
-auto ToText(TextContext&, const At<binary::DefinedType>&) -> At<text::DefinedType>;
+auto ToTextBound(TextCtx&, const At<binary::FunctionType>&) -> At<text::BoundFunctionType>;
+auto ToText(TextCtx&, const At<binary::FieldType>&) -> At<text::FieldType>;
+auto ToText(TextCtx&, const binary::FieldTypeList&) -> text::FieldTypeList;
+auto ToText(TextCtx&, const At<binary::StructType>&) -> At<text::StructType>;
+auto ToText(TextCtx&, const At<binary::ArrayType>&) -> At<text::ArrayType>;
+auto ToText(TextCtx&, const At<binary::DefinedType>&) -> At<text::DefinedType>;
 
 // Section 2: Import
-auto ToText(TextContext&, const At<binary::Import>&) -> At<text::Import>;
+auto ToText(TextCtx&, const At<binary::Import>&) -> At<text::Import>;
 
 // Section 3: Function
-auto ToText(TextContext&, const At<binary::Function>&) -> At<text::Function>;
+auto ToText(TextCtx&, const At<binary::Function>&) -> At<text::Function>;
 
 // Section 4: Table
-auto ToText(TextContext&, const At<binary::TableType>&) -> At<text::TableType>;
-auto ToText(TextContext&, const At<binary::Table>&) -> At<text::Table>;
+auto ToText(TextCtx&, const At<binary::TableType>&) -> At<text::TableType>;
+auto ToText(TextCtx&, const At<binary::Table>&) -> At<text::Table>;
 
 // Section 5: Memory
-auto ToText(TextContext&, const At<binary::Memory>&) -> At<text::Memory>;
+auto ToText(TextCtx&, const At<binary::Memory>&) -> At<text::Memory>;
 
 // Section 6: Global
-auto ToText(TextContext&, const At<binary::ConstantExpression>&) -> At<text::ConstantExpression>;
-auto ToText(TextContext&, const At<binary::GlobalType>&) -> At<text::GlobalType>;
-auto ToText(TextContext&, const At<binary::Global>&) -> At<text::Global>;
+auto ToText(TextCtx&, const At<binary::ConstantExpression>&) -> At<text::ConstantExpression>;
+auto ToText(TextCtx&, const At<binary::GlobalType>&) -> At<text::GlobalType>;
+auto ToText(TextCtx&, const At<binary::Global>&) -> At<text::Global>;
 
 // Section 7: Export
-auto ToText(TextContext&, const At<binary::Export>&) -> At<text::Export>;
+auto ToText(TextCtx&, const At<binary::Export>&) -> At<text::Export>;
 
 // Section 8: Start
-auto ToText(TextContext&, const At<binary::Start>&) -> At<text::Start>;
+auto ToText(TextCtx&, const At<binary::Start>&) -> At<text::Start>;
 
 // Section 9: Elem
-auto ToText(TextContext&, const At<binary::ElementExpression>&) -> At<text::ElementExpression>;
-auto ToText(TextContext&, const binary::ElementExpressionList&) -> text::ElementExpressionList;
-auto ToText(TextContext&, const binary::ElementList&) -> text::ElementList;
-auto ToText(TextContext&, const At<binary::ElementSegment>&) -> At<text::ElementSegment>;
+auto ToText(TextCtx&, const At<binary::ElementExpression>&) -> At<text::ElementExpression>;
+auto ToText(TextCtx&, const binary::ElementExpressionList&) -> text::ElementExpressionList;
+auto ToText(TextCtx&, const binary::ElementList&) -> text::ElementList;
+auto ToText(TextCtx&, const At<binary::ElementSegment>&) -> At<text::ElementSegment>;
 
 // Section 10: Code
-auto ToText(TextContext&, const At<binary::BlockType>&) -> At<text::BlockImmediate>;
-auto ToText(TextContext&, const At<binary::BrOnCastImmediate>&) -> At<text::BrOnCastImmediate>;
-auto ToText(TextContext&, const At<binary::BrOnExnImmediate>&) -> At<text::BrOnExnImmediate>;
-auto ToText(TextContext&, const At<binary::BrTableImmediate>&) -> At<text::BrTableImmediate>;
-auto ToText(TextContext&, const At<binary::CallIndirectImmediate>&) -> At<text::CallIndirectImmediate>;
-auto ToText(TextContext&, const At<binary::CopyImmediate>&) -> At<text::CopyImmediate>;
-auto ToText(TextContext&, const At<binary::FuncBindImmediate>&) -> At<text::FuncBindImmediate>;
-auto ToText(TextContext&, const At<binary::HeapType2Immediate>&) -> At<text::HeapType2Immediate>;
-auto ToText(TextContext&, const At<binary::InitImmediate>&) -> At<text::InitImmediate>;
-auto ToText(TextContext&, const At<binary::LetImmediate>&) -> At<text::LetImmediate>;
-auto ToText(TextContext&, const At<binary::MemArgImmediate>&) -> At<text::MemArgImmediate>;
-auto ToText(TextContext&, const At<binary::RttSubImmediate>&) -> At<text::RttSubImmediate>;
-auto ToText(TextContext&, const At<binary::StructFieldImmediate>&) -> At<text::StructFieldImmediate>;
-auto ToText(TextContext&, const At<binary::Instruction>&) -> At<text::Instruction>;
-auto ToText(TextContext&, const binary::InstructionList&) -> text::InstructionList;
+auto ToText(TextCtx&, const At<binary::BlockType>&) -> At<text::BlockImmediate>;
+auto ToText(TextCtx&, const At<binary::BrOnCastImmediate>&) -> At<text::BrOnCastImmediate>;
+auto ToText(TextCtx&, const At<binary::BrOnExnImmediate>&) -> At<text::BrOnExnImmediate>;
+auto ToText(TextCtx&, const At<binary::BrTableImmediate>&) -> At<text::BrTableImmediate>;
+auto ToText(TextCtx&, const At<binary::CallIndirectImmediate>&) -> At<text::CallIndirectImmediate>;
+auto ToText(TextCtx&, const At<binary::CopyImmediate>&) -> At<text::CopyImmediate>;
+auto ToText(TextCtx&, const At<binary::FuncBindImmediate>&) -> At<text::FuncBindImmediate>;
+auto ToText(TextCtx&, const At<binary::HeapType2Immediate>&) -> At<text::HeapType2Immediate>;
+auto ToText(TextCtx&, const At<binary::InitImmediate>&) -> At<text::InitImmediate>;
+auto ToText(TextCtx&, const At<binary::LetImmediate>&) -> At<text::LetImmediate>;
+auto ToText(TextCtx&, const At<binary::MemArgImmediate>&) -> At<text::MemArgImmediate>;
+auto ToText(TextCtx&, const At<binary::RttSubImmediate>&) -> At<text::RttSubImmediate>;
+auto ToText(TextCtx&, const At<binary::StructFieldImmediate>&) -> At<text::StructFieldImmediate>;
+auto ToText(TextCtx&, const At<binary::Instruction>&) -> At<text::Instruction>;
+auto ToText(TextCtx&, const binary::InstructionList&) -> text::InstructionList;
 
-auto ToText(TextContext&, const At<binary::UnpackedExpression>&) -> text::InstructionList;
-auto ToText(TextContext&, const binary::LocalsList&) -> At<text::BoundValueTypeList>;
-auto ToText(TextContext&, const At<binary::UnpackedCode>&, At<text::Function>&) -> At<text::Function>&;
+auto ToText(TextCtx&, const At<binary::UnpackedExpression>&) -> text::InstructionList;
+auto ToText(TextCtx&, const binary::LocalsList&) -> At<text::BoundValueTypeList>;
+auto ToText(TextCtx&, const At<binary::UnpackedCode>&, At<text::Function>&) -> At<text::Function>&;
 
 // Section 11: Data
-auto ToText(TextContext&, const At<SpanU8>&) -> text::DataItemList;
-auto ToText(TextContext&, const At<binary::DataSegment>&) -> At<text::DataSegment>;
+auto ToText(TextCtx&, const At<SpanU8>&) -> text::DataItemList;
+auto ToText(TextCtx&, const At<binary::DataSegment>&) -> At<text::DataSegment>;
 
 // Section 12: DataCount
 
 // Section 13: Event
-auto ToText(TextContext&, const At<binary::EventType>&) -> At<text::EventType>;
-auto ToText(TextContext&, const At<binary::Event>&) -> At<text::Event>;
+auto ToText(TextCtx&, const At<binary::EventType>&) -> At<text::EventType>;
+auto ToText(TextCtx&, const At<binary::Event>&) -> At<text::Event>;
 
 // Module
-auto ToText(TextContext&, const At<binary::Module>&) -> At<text::Module>;
+auto ToText(TextCtx&, const At<binary::Module>&) -> At<text::Module>;
 
 }  // namespace wasp::convert
 

--- a/include/wasp/text/read.h
+++ b/include/wasp/text/read.h
@@ -24,146 +24,146 @@
 
 namespace wasp::text {
 
-struct Context;
+struct ReadCtx;
 class Tokenizer;
 
-auto Expect(Tokenizer&, Context&, TokenType expected) -> optional<Token>;
-auto ExpectLpar(Tokenizer&, Context&, TokenType expected) -> optional<Token>;
+auto Expect(Tokenizer&, ReadCtx&, TokenType expected) -> optional<Token>;
+auto ExpectLpar(Tokenizer&, ReadCtx&, TokenType expected) -> optional<Token>;
 
 template <typename T>
-auto ReadNat(Tokenizer&, Context&) -> OptAt<T>;
-auto ReadNat32(Tokenizer&, Context&) -> OptAt<u32>;
+auto ReadNat(Tokenizer&, ReadCtx&) -> OptAt<T>;
+auto ReadNat32(Tokenizer&, ReadCtx&) -> OptAt<u32>;
 template <typename T>
-auto ReadInt(Tokenizer&, Context&) -> OptAt<T>;
+auto ReadInt(Tokenizer&, ReadCtx&) -> OptAt<T>;
 template <typename T>
-auto ReadFloat(Tokenizer&, Context&) -> OptAt<T>;
+auto ReadFloat(Tokenizer&, ReadCtx&) -> OptAt<T>;
 
-auto ReadVar(Tokenizer&, Context&) -> OptAt<Var>;
-auto ReadVarOpt(Tokenizer&, Context&) -> OptAt<Var>;
-auto ReadVarList(Tokenizer&, Context&) -> optional<VarList>;
-auto ReadNonEmptyVarList(Tokenizer&, Context&) -> optional<VarList>;
+auto ReadVar(Tokenizer&, ReadCtx&) -> OptAt<Var>;
+auto ReadVarOpt(Tokenizer&, ReadCtx&) -> OptAt<Var>;
+auto ReadVarList(Tokenizer&, ReadCtx&) -> optional<VarList>;
+auto ReadNonEmptyVarList(Tokenizer&, ReadCtx&) -> optional<VarList>;
 
-auto ReadVarUseOpt(Tokenizer&, Context&, TokenType) -> OptAt<Var>;
-auto ReadTypeUseOpt(Tokenizer&, Context&) -> OptAt<Var>;
-auto ReadFunctionTypeUse(Tokenizer&, Context&) -> optional<FunctionTypeUse>;
+auto ReadVarUseOpt(Tokenizer&, ReadCtx&, TokenType) -> OptAt<Var>;
+auto ReadTypeUseOpt(Tokenizer&, ReadCtx&) -> OptAt<Var>;
+auto ReadFunctionTypeUse(Tokenizer&, ReadCtx&) -> optional<FunctionTypeUse>;
 
-auto ReadText(Tokenizer&, Context&) -> OptAt<Text>;
-auto ReadUtf8Text(Tokenizer&, Context&) -> OptAt<Text>;
-auto ReadTextList(Tokenizer&, Context&) -> optional<TextList>;
+auto ReadText(Tokenizer&, ReadCtx&) -> OptAt<Text>;
+auto ReadUtf8Text(Tokenizer&, ReadCtx&) -> OptAt<Text>;
+auto ReadTextList(Tokenizer&, ReadCtx&) -> optional<TextList>;
 
 // Section 1: Type
 
-auto ReadBindVarOpt(Tokenizer&, Context&) -> OptAt<BindVar>;
+auto ReadBindVarOpt(Tokenizer&, ReadCtx&) -> OptAt<BindVar>;
 
-auto ReadBoundValueTypeList(Tokenizer&, Context&, TokenType)
+auto ReadBoundValueTypeList(Tokenizer&, ReadCtx&, TokenType)
     -> optional<BoundValueTypeList>;
-auto ReadBoundParamList(Tokenizer&, Context&) -> optional<BoundValueTypeList>;
+auto ReadBoundParamList(Tokenizer&, ReadCtx&) -> optional<BoundValueTypeList>;
 
-auto ReadUnboundValueTypeList(Tokenizer&, Context&, TokenType)
+auto ReadUnboundValueTypeList(Tokenizer&, ReadCtx&, TokenType)
     -> optional<ValueTypeList>;
-auto ReadParamList(Tokenizer&, Context&) -> optional<ValueTypeList>;
-auto ReadResultList(Tokenizer&, Context&) -> optional<ValueTypeList>;
+auto ReadParamList(Tokenizer&, ReadCtx&) -> optional<ValueTypeList>;
+auto ReadResultList(Tokenizer&, ReadCtx&) -> optional<ValueTypeList>;
 
-auto ReadRtt(Tokenizer&, Context&) -> OptAt<Rtt>;
+auto ReadRtt(Tokenizer&, ReadCtx&) -> OptAt<Rtt>;
 
-auto ReadValueType(Tokenizer&, Context&) -> OptAt<ValueType>;
-auto ReadValueTypeList(Tokenizer&, Context&) -> optional<ValueTypeList>;
+auto ReadValueType(Tokenizer&, ReadCtx&) -> OptAt<ValueType>;
+auto ReadValueTypeList(Tokenizer&, ReadCtx&) -> optional<ValueTypeList>;
 
-auto ReadBoundFunctionType(Tokenizer&, Context&) -> OptAt<BoundFunctionType>;
+auto ReadBoundFunctionType(Tokenizer&, ReadCtx&) -> OptAt<BoundFunctionType>;
 
-auto ReadStorageType(Tokenizer&, Context&) -> OptAt<StorageType>;
-auto ReadFieldTypeContents(Tokenizer&, Context&) -> OptAt<FieldType>;
-auto ReadFieldType(Tokenizer&, Context&) -> OptAt<FieldType>;
-auto ReadFieldTypeList(Tokenizer&, Context&) -> optional<FieldTypeList>;
+auto ReadStorageType(Tokenizer&, ReadCtx&) -> OptAt<StorageType>;
+auto ReadFieldTypeContents(Tokenizer&, ReadCtx&) -> OptAt<FieldType>;
+auto ReadFieldType(Tokenizer&, ReadCtx&) -> OptAt<FieldType>;
+auto ReadFieldTypeList(Tokenizer&, ReadCtx&) -> optional<FieldTypeList>;
 
-auto ReadStructType(Tokenizer&, Context&) -> OptAt<StructType>;
-auto ReadArrayType(Tokenizer&, Context&) -> OptAt<ArrayType>;
+auto ReadStructType(Tokenizer&, ReadCtx&) -> OptAt<StructType>;
+auto ReadArrayType(Tokenizer&, ReadCtx&) -> OptAt<ArrayType>;
 
-auto ReadDefinedType(Tokenizer&, Context&) -> OptAt<DefinedType>;
+auto ReadDefinedType(Tokenizer&, ReadCtx&) -> OptAt<DefinedType>;
 
 // Section 2: Import
 
-auto ReadInlineImportOpt(Tokenizer&, Context&) -> OptAt<InlineImport>;
-auto ReadImport(Tokenizer&, Context&) -> OptAt<Import>;
+auto ReadInlineImportOpt(Tokenizer&, ReadCtx&) -> OptAt<InlineImport>;
+auto ReadImport(Tokenizer&, ReadCtx&) -> OptAt<Import>;
 
 // Section 3: Function
 
-auto ReadLocalList(Tokenizer&, Context&) -> optional<BoundValueTypeList>;
-auto ReadFunctionType(Tokenizer&, Context&) -> OptAt<FunctionType>;
-auto ReadFunction(Tokenizer&, Context&) -> OptAt<Function>;
+auto ReadLocalList(Tokenizer&, ReadCtx&) -> optional<BoundValueTypeList>;
+auto ReadFunctionType(Tokenizer&, ReadCtx&) -> OptAt<FunctionType>;
+auto ReadFunction(Tokenizer&, ReadCtx&) -> OptAt<Function>;
 
 // Section 4: Table
 
 enum class LimitsKind { Memory, Table };
 enum class AllowFuncref { No, Yes };
 
-auto ReadIndexTypeOpt(Tokenizer&, Context&) -> OptAt<IndexType>;
-auto ReadLimits(Tokenizer&, Context&, LimitsKind) -> OptAt<Limits>;
-auto ReadHeapType(Tokenizer&, Context&) -> OptAt<HeapType>;
-auto ReadRefType(Tokenizer&, Context&) -> OptAt<RefType>;
-auto ReadReferenceType(Tokenizer&, Context&, AllowFuncref = AllowFuncref::Yes)
+auto ReadIndexTypeOpt(Tokenizer&, ReadCtx&) -> OptAt<IndexType>;
+auto ReadLimits(Tokenizer&, ReadCtx&, LimitsKind) -> OptAt<Limits>;
+auto ReadHeapType(Tokenizer&, ReadCtx&) -> OptAt<HeapType>;
+auto ReadRefType(Tokenizer&, ReadCtx&) -> OptAt<RefType>;
+auto ReadReferenceType(Tokenizer&, ReadCtx&, AllowFuncref = AllowFuncref::Yes)
     -> OptAt<ReferenceType>;
 auto ReadReferenceTypeOpt(Tokenizer&,
-                          Context&,
+                          ReadCtx&,
                           AllowFuncref = AllowFuncref::Yes)
     -> OptAt<ReferenceType>;
 
-auto ReadTableType(Tokenizer&, Context&) -> OptAt<TableType>;
-auto ReadTable(Tokenizer&, Context&) -> OptAt<Table>;
+auto ReadTableType(Tokenizer&, ReadCtx&) -> OptAt<TableType>;
+auto ReadTable(Tokenizer&, ReadCtx&) -> OptAt<Table>;
 
 // Section 5: Memory
 
 template <typename T>
-bool ReadIntsIntoBuffer(Tokenizer&, Context&, Buffer&);
+bool ReadIntsIntoBuffer(Tokenizer&, ReadCtx&, Buffer&);
 template <typename T>
-bool ReadFloatsIntoBuffer(Tokenizer&, Context&, Buffer&);
+bool ReadFloatsIntoBuffer(Tokenizer&, ReadCtx&, Buffer&);
 
-auto ReadSimdConst(Tokenizer&, Context&) -> OptAt<v128>;
-bool ReadSimdConstsIntoBuffer(Tokenizer&, Context&, Buffer&);
+auto ReadSimdConst(Tokenizer&, ReadCtx&) -> OptAt<v128>;
+bool ReadSimdConstsIntoBuffer(Tokenizer&, ReadCtx&, Buffer&);
 
-auto ReadNumericData(Tokenizer&, Context&) -> OptAt<NumericData>;
-auto ReadDataItem(Tokenizer&, Context&) -> OptAt<DataItem>;
-auto ReadDataItemList(Tokenizer&, Context&) -> optional<DataItemList>;
-auto ReadMemoryType(Tokenizer&, Context&) -> OptAt<MemoryType>;
-auto ReadMemory(Tokenizer&, Context&) -> OptAt<Memory>;
+auto ReadNumericData(Tokenizer&, ReadCtx&) -> OptAt<NumericData>;
+auto ReadDataItem(Tokenizer&, ReadCtx&) -> OptAt<DataItem>;
+auto ReadDataItemList(Tokenizer&, ReadCtx&) -> optional<DataItemList>;
+auto ReadMemoryType(Tokenizer&, ReadCtx&) -> OptAt<MemoryType>;
+auto ReadMemory(Tokenizer&, ReadCtx&) -> OptAt<Memory>;
 
 // Section 6: Global
 
-auto ReadConstantExpression(Tokenizer&, Context&) -> OptAt<ConstantExpression>;
-auto ReadGlobalType(Tokenizer&, Context&) -> OptAt<GlobalType>;
-auto ReadGlobal(Tokenizer&, Context&) -> OptAt<Global>;
+auto ReadConstantExpression(Tokenizer&, ReadCtx&) -> OptAt<ConstantExpression>;
+auto ReadGlobalType(Tokenizer&, ReadCtx&) -> OptAt<GlobalType>;
+auto ReadGlobal(Tokenizer&, ReadCtx&) -> OptAt<Global>;
 
 // Section 7: Export
 
-auto ReadInlineExport(Tokenizer&, Context&) -> OptAt<InlineExport>;
-auto ReadInlineExportList(Tokenizer&, Context&) -> optional<InlineExportList>;
-auto ReadExport(Tokenizer&, Context&) -> OptAt<Export>;
+auto ReadInlineExport(Tokenizer&, ReadCtx&) -> OptAt<InlineExport>;
+auto ReadInlineExportList(Tokenizer&, ReadCtx&) -> optional<InlineExportList>;
+auto ReadExport(Tokenizer&, ReadCtx&) -> OptAt<Export>;
 
 // Section 8: Start
 
-auto ReadStart(Tokenizer&, Context&) -> OptAt<Start>;
+auto ReadStart(Tokenizer&, ReadCtx&) -> OptAt<Start>;
 
 // Section 9: Elem
 
-auto ReadOffsetExpression(Tokenizer&, Context&) -> OptAt<ConstantExpression>;
-auto ReadElementExpression(Tokenizer&, Context&) -> OptAt<ElementExpression>;
-auto ReadElementExpressionList(Tokenizer&, Context&)
+auto ReadOffsetExpression(Tokenizer&, ReadCtx&) -> OptAt<ConstantExpression>;
+auto ReadElementExpression(Tokenizer&, ReadCtx&) -> OptAt<ElementExpression>;
+auto ReadElementExpressionList(Tokenizer&, ReadCtx&)
     -> optional<ElementExpressionList>;
-auto ReadTableUseOpt(Tokenizer&, Context&) -> OptAt<Var>;
-auto ReadElementSegment(Tokenizer&, Context&) -> OptAt<ElementSegment>;
+auto ReadTableUseOpt(Tokenizer&, ReadCtx&) -> OptAt<Var>;
+auto ReadElementSegment(Tokenizer&, ReadCtx&) -> OptAt<ElementSegment>;
 
 // Section 10: Code
 
-auto ReadNameEqNatOpt(Tokenizer&, Context&, TokenType, u32) -> OptAt<u32>;
-auto ReadAlignOpt(Tokenizer&, Context&) -> OptAt<u32>;
-auto ReadOffsetOpt(Tokenizer&, Context&) -> OptAt<u32>;
+auto ReadNameEqNatOpt(Tokenizer&, ReadCtx&, TokenType, u32) -> OptAt<u32>;
+auto ReadAlignOpt(Tokenizer&, ReadCtx&) -> OptAt<u32>;
+auto ReadOffsetOpt(Tokenizer&, ReadCtx&) -> OptAt<u32>;
 
-auto ReadSimdLane(Tokenizer&, Context&) -> OptAt<u8>;
-auto ReadSimdShuffleImmediate(Tokenizer&, Context&) -> OptAt<ShuffleImmediate>;
+auto ReadSimdLane(Tokenizer&, ReadCtx&) -> OptAt<u8>;
+auto ReadSimdShuffleImmediate(Tokenizer&, ReadCtx&) -> OptAt<ShuffleImmediate>;
 template <typename T, size_t N>
-auto ReadSimdValues(Tokenizer&, Context&) -> OptAt<v128>;
+auto ReadSimdValues(Tokenizer&, ReadCtx&) -> OptAt<v128>;
 
-auto ReadHeapType2Immediate(Tokenizer&, Context&) -> OptAt<HeapType2Immediate>;
+auto ReadHeapType2Immediate(Tokenizer&, ReadCtx&) -> OptAt<HeapType2Immediate>;
 
 bool IsPlainInstruction(Token);
 bool IsBlockInstruction(Token);
@@ -171,74 +171,74 @@ bool IsExpression(Tokenizer&);
 bool IsElementExpression(Tokenizer&);
 bool IsInstruction(Tokenizer&);
 
-auto ReadPlainInstruction(Tokenizer&, Context&) -> OptAt<Instruction>;
-auto ReadLabelOpt(Tokenizer&, Context&) -> OptAt<BindVar>;
-bool ReadEndLabelOpt(Tokenizer&, Context&, OptAt<BindVar>);
-auto ReadBlockImmediate(Tokenizer&, Context&) -> OptAt<BlockImmediate>;
-auto ReadLetImmediate(Tokenizer&, Context&) -> OptAt<LetImmediate>;
-void EndBlock(Context&);
+auto ReadPlainInstruction(Tokenizer&, ReadCtx&) -> OptAt<Instruction>;
+auto ReadLabelOpt(Tokenizer&, ReadCtx&) -> OptAt<BindVar>;
+bool ReadEndLabelOpt(Tokenizer&, ReadCtx&, OptAt<BindVar>);
+auto ReadBlockImmediate(Tokenizer&, ReadCtx&) -> OptAt<BlockImmediate>;
+auto ReadLetImmediate(Tokenizer&, ReadCtx&) -> OptAt<LetImmediate>;
+void EndBlock(ReadCtx&);
 
-bool ReadOpcodeOpt(Tokenizer&, Context&, InstructionList&, TokenType);
-bool ExpectOpcode(Tokenizer&, Context&, InstructionList&, TokenType);
-bool ReadBlockInstruction(Tokenizer&, Context&, InstructionList&);
-bool ReadLetInstruction(Tokenizer&, Context&, InstructionList&);
-bool ReadInstruction(Tokenizer&, Context&, InstructionList&);
-bool ReadInstructionList(Tokenizer&, Context&, InstructionList&);
-bool ReadRparAsEndInstruction(Tokenizer&, Context&, InstructionList&);
-bool ReadExpression(Tokenizer&, Context&, InstructionList&);
-bool ReadExpressionList(Tokenizer&, Context&, InstructionList&);
+bool ReadOpcodeOpt(Tokenizer&, ReadCtx&, InstructionList&, TokenType);
+bool ExpectOpcode(Tokenizer&, ReadCtx&, InstructionList&, TokenType);
+bool ReadBlockInstruction(Tokenizer&, ReadCtx&, InstructionList&);
+bool ReadLetInstruction(Tokenizer&, ReadCtx&, InstructionList&);
+bool ReadInstruction(Tokenizer&, ReadCtx&, InstructionList&);
+bool ReadInstructionList(Tokenizer&, ReadCtx&, InstructionList&);
+bool ReadRparAsEndInstruction(Tokenizer&, ReadCtx&, InstructionList&);
+bool ReadExpression(Tokenizer&, ReadCtx&, InstructionList&);
+bool ReadExpressionList(Tokenizer&, ReadCtx&, InstructionList&);
 
 // Section 11: Data
 
-auto ReadMemoryUseOpt(Tokenizer&, Context&) -> OptAt<Var>;
-auto ReadDataSegment(Tokenizer&, Context&) -> OptAt<DataSegment>;
+auto ReadMemoryUseOpt(Tokenizer&, ReadCtx&) -> OptAt<Var>;
+auto ReadDataSegment(Tokenizer&, ReadCtx&) -> OptAt<DataSegment>;
 
 // Section 12: DataCount
 
 // Section 13: Event
 
-auto ReadEventType(Tokenizer&, Context&) -> OptAt<EventType>;
-auto ReadEvent(Tokenizer&, Context&) -> OptAt<Event>;
+auto ReadEventType(Tokenizer&, ReadCtx&) -> OptAt<EventType>;
+auto ReadEvent(Tokenizer&, ReadCtx&) -> OptAt<Event>;
 
 // Module
 
 bool IsModuleItem(Tokenizer&);
-auto ReadModuleItem(Tokenizer&, Context&) -> OptAt<ModuleItem>;
-auto ReadModule(Tokenizer&, Context&) -> optional<Module>;
-auto ReadSingleModule(Tokenizer&, Context&) -> optional<Module>;
+auto ReadModuleItem(Tokenizer&, ReadCtx&) -> OptAt<ModuleItem>;
+auto ReadModule(Tokenizer&, ReadCtx&) -> optional<Module>;
+auto ReadSingleModule(Tokenizer&, ReadCtx&) -> optional<Module>;
 
 // Script
 
-auto ReadModuleVarOpt(Tokenizer&, Context&) -> OptAt<ModuleVar>;
-auto ReadScriptModule(Tokenizer&, Context&) -> OptAt<ScriptModule>;
+auto ReadModuleVarOpt(Tokenizer&, ReadCtx&) -> OptAt<ModuleVar>;
+auto ReadScriptModule(Tokenizer&, ReadCtx&) -> OptAt<ScriptModule>;
 
 // Action
 bool IsConst(Tokenizer&);
-auto ReadConst(Tokenizer&, Context&) -> OptAt<Const>;
-auto ReadConstList(Tokenizer&, Context&) -> optional<ConstList>;
-auto ReadInvokeAction(Tokenizer&, Context&) -> OptAt<InvokeAction>;
-auto ReadGetAction(Tokenizer&, Context&) -> OptAt<GetAction>;
-auto ReadAction(Tokenizer&, Context&) -> OptAt<Action>;
+auto ReadConst(Tokenizer&, ReadCtx&) -> OptAt<Const>;
+auto ReadConstList(Tokenizer&, ReadCtx&) -> optional<ConstList>;
+auto ReadInvokeAction(Tokenizer&, ReadCtx&) -> OptAt<InvokeAction>;
+auto ReadGetAction(Tokenizer&, ReadCtx&) -> OptAt<GetAction>;
+auto ReadAction(Tokenizer&, ReadCtx&) -> OptAt<Action>;
 
 // Assertion
-auto ReadModuleAssertion(Tokenizer&, Context&) -> OptAt<ModuleAssertion>;
-auto ReadActionAssertion(Tokenizer&, Context&) -> OptAt<ActionAssertion>;
+auto ReadModuleAssertion(Tokenizer&, ReadCtx&) -> OptAt<ModuleAssertion>;
+auto ReadActionAssertion(Tokenizer&, ReadCtx&) -> OptAt<ActionAssertion>;
 template <typename T>
-auto ReadFloatResult(Tokenizer&, Context&) -> OptAt<FloatResult<T>>;
+auto ReadFloatResult(Tokenizer&, ReadCtx&) -> OptAt<FloatResult<T>>;
 template <typename T, size_t N>
-auto ReadSimdFloatResult(Tokenizer&, Context&) -> OptAt<ReturnResult>;
+auto ReadSimdFloatResult(Tokenizer&, ReadCtx&) -> OptAt<ReturnResult>;
 
 bool IsReturnResult(Tokenizer&);
-auto ReadReturnResult(Tokenizer&, Context&) -> OptAt<ReturnResult>;
-auto ReadReturnResultList(Tokenizer&, Context&) -> optional<ReturnResultList>;
-auto ReadReturnAssertion(Tokenizer&, Context&) -> OptAt<ReturnAssertion>;
-auto ReadAssertion(Tokenizer&, Context&) -> OptAt<Assertion>;
+auto ReadReturnResult(Tokenizer&, ReadCtx&) -> OptAt<ReturnResult>;
+auto ReadReturnResultList(Tokenizer&, ReadCtx&) -> optional<ReturnResultList>;
+auto ReadReturnAssertion(Tokenizer&, ReadCtx&) -> OptAt<ReturnAssertion>;
+auto ReadAssertion(Tokenizer&, ReadCtx&) -> OptAt<Assertion>;
 
-auto ReadRegister(Tokenizer&, Context&) -> OptAt<Register>;
+auto ReadRegister(Tokenizer&, ReadCtx&) -> OptAt<Register>;
 
 bool IsCommand(Tokenizer&);
-auto ReadCommand(Tokenizer&, Context&) -> OptAt<Command>;
-auto ReadScript(Tokenizer&, Context&) -> optional<Script>;
+auto ReadCommand(Tokenizer&, ReadCtx&) -> OptAt<Command>;
+auto ReadScript(Tokenizer&, ReadCtx&) -> optional<Script>;
 
 }  // namespace wasp::text
 

--- a/include/wasp/text/read/read_ctx.h
+++ b/include/wasp/text/read/read_ctx.h
@@ -14,21 +14,31 @@
 // limitations under the License.
 //
 
-#include "wasp/binary/read/context.h"
+#ifndef WASP_TEXT_READ_CONTEXT_H_
+#define WASP_TEXT_READ_CONTEXT_H_
 
-namespace wasp::binary {
+#include "wasp/base/features.h"
 
-Context::Context(Errors& errors) : errors(errors) {}
+namespace wasp {
 
-Context::Context(const Features& features, Errors& errors)
-    : features(features), errors(errors) {}
+class Errors;
 
-void Context::Reset() {
-  last_section_id.reset();
-  defined_function_count = 0;
-  declared_data_count.reset();
-  code_count = 0;
-  data_count = 0;
-}
+namespace text {
 
-}  // namespace wasp::binary
+struct ReadCtx {
+  explicit ReadCtx(Errors&);
+  explicit ReadCtx(const Features&, Errors&);
+
+  void BeginModule();    // Reset all module-specific context.
+
+  Features features;
+  Errors& errors;
+
+  bool seen_non_import = false;
+  bool seen_start = false;
+};
+
+}  // namespace text
+}  // namespace wasp
+
+#endif  // WASP_TEXT_READ_CONTEXT_H_

--- a/include/wasp/text/resolve.h
+++ b/include/wasp/text/resolve.h
@@ -25,7 +25,7 @@ class Errors;
 
 namespace text {
 
-struct ResolveContext;
+struct ResolveCtx;
 class NameMap;
 
 // Primary API; resolve either a Module or a Script.
@@ -42,94 +42,94 @@ void Resolve(Script&, Errors&);
 //   (type $A (func))
 //   (type $B (func (param (ref $A)))
 //
-void DefineTypes(ResolveContext&, const DefinedType&);
-void DefineTypes(ResolveContext&, const ModuleItem&);
-void DefineTypes(ResolveContext&, const Module&);
+void DefineTypes(ResolveCtx&, const DefinedType&);
+void DefineTypes(ResolveCtx&, const ModuleItem&);
+void DefineTypes(ResolveCtx&, const Module&);
 
 // Define() is the second pass over the Module, to handle all non-type names,
 // and to create a mapping of function types to indexes.
-void Define(ResolveContext&, const OptAt<BindVar>&, NameMap&);
-void Define(ResolveContext&, const BoundValueTypeList&, NameMap&);
-void Define(ResolveContext&, const FieldType&);
-void Define(ResolveContext&, const FieldTypeList&);
-void Define(ResolveContext&, const DefinedType&);
-void Define(ResolveContext&, const FunctionDesc&);
-void Define(ResolveContext&, const TableDesc&);
-void Define(ResolveContext&, const MemoryDesc&);
-void Define(ResolveContext&, const GlobalDesc&);
-void Define(ResolveContext&, const EventDesc&);
-void Define(ResolveContext&, const Import&);
-void Define(ResolveContext&, const ElementSegment&);
-void Define(ResolveContext&, const DataSegment&);
-void Define(ResolveContext&, const ModuleItem&);
-void Define(ResolveContext&, const Module&);
+void Define(ResolveCtx&, const OptAt<BindVar>&, NameMap&);
+void Define(ResolveCtx&, const BoundValueTypeList&, NameMap&);
+void Define(ResolveCtx&, const FieldType&);
+void Define(ResolveCtx&, const FieldTypeList&);
+void Define(ResolveCtx&, const DefinedType&);
+void Define(ResolveCtx&, const FunctionDesc&);
+void Define(ResolveCtx&, const TableDesc&);
+void Define(ResolveCtx&, const MemoryDesc&);
+void Define(ResolveCtx&, const GlobalDesc&);
+void Define(ResolveCtx&, const EventDesc&);
+void Define(ResolveCtx&, const Import&);
+void Define(ResolveCtx&, const ElementSegment&);
+void Define(ResolveCtx&, const DataSegment&);
+void Define(ResolveCtx&, const ModuleItem&);
+void Define(ResolveCtx&, const Module&);
 
 // Resolve() is the final pass over the Module, which uses all the
 // names/function types defined in DefineTypes() and Define() to convert them
 // to their respective indexes.
-void Resolve(ResolveContext&, At<Var>&, NameMap&);
-void Resolve(ResolveContext&, OptAt<Var>&, NameMap&);
-void Resolve(ResolveContext&, VarList&, NameMap&);
-void Resolve(ResolveContext&, HeapType&);
-void Resolve(ResolveContext&, RefType&);
-void Resolve(ResolveContext&, ReferenceType&);
-void Resolve(ResolveContext&, Rtt&);
-void Resolve(ResolveContext&, ValueType&);
-void Resolve(ResolveContext&, ValueTypeList&);
-void Resolve(ResolveContext&, StorageType&);
-void Resolve(ResolveContext&, FunctionType&);
-void Resolve(ResolveContext&, FunctionTypeUse&);
-void Resolve(ResolveContext&, BoundValueType&);
-void Resolve(ResolveContext&, BoundValueTypeList&);
-void Resolve(ResolveContext&, BoundFunctionType&);
-void Resolve(ResolveContext&, OptAt<Var>& type_use, At<BoundFunctionType>&);
-void Resolve(ResolveContext&, FieldType&);
-void Resolve(ResolveContext&, FieldTypeList&);
-void Resolve(ResolveContext&, StructType&);
-void Resolve(ResolveContext&, ArrayType&);
-void Resolve(ResolveContext&, DefinedType&);
-void Resolve(ResolveContext&, BlockImmediate&);
-void Resolve(ResolveContext&, BrOnCastImmediate&);
-void Resolve(ResolveContext&, BrOnExnImmediate&);
-void Resolve(ResolveContext&, BrTableImmediate&);
-void Resolve(ResolveContext&, CallIndirectImmediate&);
-void Resolve(ResolveContext&, CopyImmediate&, NameMap&);
-void Resolve(ResolveContext&, HeapType2Immediate&);
-void Resolve(ResolveContext&, InitImmediate&, NameMap& segment, NameMap& dst);
-void Resolve(ResolveContext&, LetImmediate&);
-void Resolve(ResolveContext&, RttSubImmediate&);
-void Resolve(ResolveContext&, StructFieldImmediate&);
-void Resolve(ResolveContext&, Instruction&);
-void Resolve(ResolveContext&, InstructionList&);
-void Resolve(ResolveContext&, FunctionDesc&);
-void Resolve(ResolveContext&, TableType&);
-void Resolve(ResolveContext&, TableDesc&);
-void Resolve(ResolveContext&, GlobalType&);
-void Resolve(ResolveContext&, GlobalDesc&);
-void Resolve(ResolveContext&, EventType&);
-void Resolve(ResolveContext&, EventDesc&);
-void Resolve(ResolveContext&, Import&);
-void Resolve(ResolveContext&, Function&);
-void Resolve(ResolveContext&, ConstantExpression&);
-void Resolve(ResolveContext&, ElementExpression&);
-void Resolve(ResolveContext&, ElementExpressionList&);
-void Resolve(ResolveContext&, ElementListWithExpressions&);
-void Resolve(ResolveContext&, ElementListWithVars&);
-void Resolve(ResolveContext&, ElementList&);
-void Resolve(ResolveContext&, Table&);
-void Resolve(ResolveContext&, Global&);
-void Resolve(ResolveContext&, Export&);
-void Resolve(ResolveContext&, Start&);
-void Resolve(ResolveContext&, ElementSegment&);
-void Resolve(ResolveContext&, DataSegment&);
-void Resolve(ResolveContext&, Event&);
-void Resolve(ResolveContext&, ModuleItem&);
-void Resolve(ResolveContext&, Module&);
-void Resolve(ResolveContext&, ScriptModule&);
-void Resolve(ResolveContext&, ModuleAssertion&);
-void Resolve(ResolveContext&, Assertion&);
-void Resolve(ResolveContext&, Command&);
-void Resolve(ResolveContext&, Script&);
+void Resolve(ResolveCtx&, At<Var>&, NameMap&);
+void Resolve(ResolveCtx&, OptAt<Var>&, NameMap&);
+void Resolve(ResolveCtx&, VarList&, NameMap&);
+void Resolve(ResolveCtx&, HeapType&);
+void Resolve(ResolveCtx&, RefType&);
+void Resolve(ResolveCtx&, ReferenceType&);
+void Resolve(ResolveCtx&, Rtt&);
+void Resolve(ResolveCtx&, ValueType&);
+void Resolve(ResolveCtx&, ValueTypeList&);
+void Resolve(ResolveCtx&, StorageType&);
+void Resolve(ResolveCtx&, FunctionType&);
+void Resolve(ResolveCtx&, FunctionTypeUse&);
+void Resolve(ResolveCtx&, BoundValueType&);
+void Resolve(ResolveCtx&, BoundValueTypeList&);
+void Resolve(ResolveCtx&, BoundFunctionType&);
+void Resolve(ResolveCtx&, OptAt<Var>& type_use, At<BoundFunctionType>&);
+void Resolve(ResolveCtx&, FieldType&);
+void Resolve(ResolveCtx&, FieldTypeList&);
+void Resolve(ResolveCtx&, StructType&);
+void Resolve(ResolveCtx&, ArrayType&);
+void Resolve(ResolveCtx&, DefinedType&);
+void Resolve(ResolveCtx&, BlockImmediate&);
+void Resolve(ResolveCtx&, BrOnCastImmediate&);
+void Resolve(ResolveCtx&, BrOnExnImmediate&);
+void Resolve(ResolveCtx&, BrTableImmediate&);
+void Resolve(ResolveCtx&, CallIndirectImmediate&);
+void Resolve(ResolveCtx&, CopyImmediate&, NameMap&);
+void Resolve(ResolveCtx&, HeapType2Immediate&);
+void Resolve(ResolveCtx&, InitImmediate&, NameMap& segment, NameMap& dst);
+void Resolve(ResolveCtx&, LetImmediate&);
+void Resolve(ResolveCtx&, RttSubImmediate&);
+void Resolve(ResolveCtx&, StructFieldImmediate&);
+void Resolve(ResolveCtx&, Instruction&);
+void Resolve(ResolveCtx&, InstructionList&);
+void Resolve(ResolveCtx&, FunctionDesc&);
+void Resolve(ResolveCtx&, TableType&);
+void Resolve(ResolveCtx&, TableDesc&);
+void Resolve(ResolveCtx&, GlobalType&);
+void Resolve(ResolveCtx&, GlobalDesc&);
+void Resolve(ResolveCtx&, EventType&);
+void Resolve(ResolveCtx&, EventDesc&);
+void Resolve(ResolveCtx&, Import&);
+void Resolve(ResolveCtx&, Function&);
+void Resolve(ResolveCtx&, ConstantExpression&);
+void Resolve(ResolveCtx&, ElementExpression&);
+void Resolve(ResolveCtx&, ElementExpressionList&);
+void Resolve(ResolveCtx&, ElementListWithExpressions&);
+void Resolve(ResolveCtx&, ElementListWithVars&);
+void Resolve(ResolveCtx&, ElementList&);
+void Resolve(ResolveCtx&, Table&);
+void Resolve(ResolveCtx&, Global&);
+void Resolve(ResolveCtx&, Export&);
+void Resolve(ResolveCtx&, Start&);
+void Resolve(ResolveCtx&, ElementSegment&);
+void Resolve(ResolveCtx&, DataSegment&);
+void Resolve(ResolveCtx&, Event&);
+void Resolve(ResolveCtx&, ModuleItem&);
+void Resolve(ResolveCtx&, Module&);
+void Resolve(ResolveCtx&, ScriptModule&);
+void Resolve(ResolveCtx&, ModuleAssertion&);
+void Resolve(ResolveCtx&, Assertion&);
+void Resolve(ResolveCtx&, Command&);
+void Resolve(ResolveCtx&, Script&);
 
 }  // namespace text
 }  // namespace wasp

--- a/include/wasp/text/resolve_ctx.h
+++ b/include/wasp/text/resolve_ctx.h
@@ -72,8 +72,8 @@ class FunctionTypeMap {
   List deferred_list_;
 };
 
-struct ResolveContext {
-  explicit ResolveContext(Errors&);
+struct ResolveCtx {
+  explicit ResolveCtx(Errors&);
 
   void BeginModule();    // Reset all module-specific context.
   void BeginFunction();  // Reset all function-specific context.

--- a/include/wasp/text/write.h
+++ b/include/wasp/text/write.h
@@ -31,8 +31,7 @@
 
 namespace wasp::text {
 
-// TODO: Rename to Context and put in write namespace?
-struct WriteContext {
+struct WriteCtx {
   void ClearSeparator() { separator = ""; }
   void Space() { separator = " "; }
   void Newline() { separator = indent; }
@@ -55,539 +54,501 @@ struct WriteContext {
 
 // WriteRaw
 template <typename Iterator>
-Iterator WriteRaw(WriteContext& context, char value, Iterator out) {
+Iterator WriteRaw(WriteCtx& ctx, char value, Iterator out) {
   *out++ = value;
   return out;
 }
 
 template <typename Iterator>
-Iterator WriteRaw(WriteContext& context, string_view value, Iterator out) {
+Iterator WriteRaw(WriteCtx& ctx, string_view value, Iterator out) {
   return std::copy(value.begin(), value.end(), out);
 }
 
 template <typename Iterator>
-Iterator WriteRaw(WriteContext& context,
-                  const std::string& value,
-                  Iterator out) {
+Iterator WriteRaw(WriteCtx& ctx, const std::string& value, Iterator out) {
   return std::copy(value.begin(), value.end(), out);
 }
 
 template <typename Iterator>
-Iterator WriteSeparator(WriteContext& context, Iterator out) {
-  out = WriteRaw(context, context.separator, out);
-  context.ClearSeparator();
+Iterator WriteSeparator(WriteCtx& ctx, Iterator out) {
+  out = WriteRaw(ctx, ctx.separator, out);
+  ctx.ClearSeparator();
   return out;
 }
 
 // WriteFormat
 template <typename Iterator, typename T>
-Iterator WriteFormat(WriteContext& context, const T& value, Iterator out) {
-  out = WriteSeparator(context, out);
-  out = WriteRaw(context, concat(value), out);
-  context.Space();
+Iterator WriteFormat(WriteCtx& ctx, const T& value, Iterator out) {
+  out = WriteSeparator(ctx, out);
+  out = WriteRaw(ctx, concat(value), out);
+  ctx.Space();
   return out;
 }
 
 template <typename Iterator>
-Iterator WriteLpar(WriteContext& context, Iterator out) {
-  out = WriteSeparator(context, out);
-  out = WriteRaw(context, '(', out);
+Iterator WriteLpar(WriteCtx& ctx, Iterator out) {
+  out = WriteSeparator(ctx, out);
+  out = WriteRaw(ctx, '(', out);
   return out;
 }
 
 template <typename Iterator>
-Iterator WriteLpar(WriteContext& context, string_view name, Iterator out) {
-  out = WriteLpar(context, out);
-  out = WriteRaw(context, name, out);
-  context.Space();
+Iterator WriteLpar(WriteCtx& ctx, string_view name, Iterator out) {
+  out = WriteLpar(ctx, out);
+  out = WriteRaw(ctx, name, out);
+  ctx.Space();
   return out;
 }
 
 template <typename Iterator>
-Iterator WriteRpar(WriteContext& context, Iterator out) {
-  context.ClearSeparator();
-  out = WriteRaw(context, ')', out);
-  context.Space();
+Iterator WriteRpar(WriteCtx& ctx, Iterator out) {
+  ctx.ClearSeparator();
+  out = WriteRaw(ctx, ')', out);
+  ctx.Space();
   return out;
 }
 
 template <typename Iterator, typename SourceIter>
-Iterator WriteRange(WriteContext& context,
+Iterator WriteRange(WriteCtx& ctx,
                     SourceIter begin,
                     SourceIter end,
                     Iterator out) {
   for (auto iter = begin; iter != end; ++iter) {
-    out = Write(context, *iter, out);
+    out = Write(ctx, *iter, out);
   }
   return out;
 }
 
 template <typename Iterator, typename T>
-Iterator WriteVector(WriteContext& context,
+Iterator WriteVector(WriteCtx& ctx,
                      const std::vector<T>& values,
                      Iterator out) {
-  return WriteRange(context, values.begin(), values.end(), out);
+  return WriteRange(ctx, values.begin(), values.end(), out);
 }
 
 template <typename Iterator, typename T>
-Iterator Write(WriteContext& context,
-               const optional<T>& value_opt,
-               Iterator out) {
+Iterator Write(WriteCtx& ctx, const optional<T>& value_opt, Iterator out) {
   if (value_opt) {
-    out = Write(context, *value_opt, out);
+    out = Write(ctx, *value_opt, out);
   }
   return out;
 }
 
 template <typename Iterator, typename T>
-Iterator Write(WriteContext& context, const At<T>& value, Iterator out) {
-  return Write(context, *value, out);
+Iterator Write(WriteCtx& ctx, const At<T>& value, Iterator out) {
+  return Write(ctx, *value, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, string_view value, Iterator out) {
-  out = WriteSeparator(context, out);
-  out = WriteRaw(context, value, out);
-  context.Space();
+Iterator Write(WriteCtx& ctx, string_view value, Iterator out) {
+  out = WriteSeparator(ctx, out);
+  out = WriteRaw(ctx, value, out);
+  ctx.Space();
   return out;
 }
 
 template <typename Iterator, typename T>
-Iterator WriteNat(WriteContext& context, const At<T>& value, Iterator out) {
-  return WriteNat(context, *value, out);
+Iterator WriteNat(WriteCtx& ctx, const At<T>& value, Iterator out) {
+  return WriteNat(ctx, *value, out);
 }
 
 template <typename Iterator, typename T>
-Iterator WriteInt(WriteContext& context, const At<T>& value, Iterator out) {
-  return WriteInt(context, *value, out);
+Iterator WriteInt(WriteCtx& ctx, const At<T>& value, Iterator out) {
+  return WriteInt(ctx, *value, out);
 }
 
 template <typename Iterator, typename T>
-Iterator WriteFloat(WriteContext& context, const At<T>& value, Iterator out) {
-  return WriteFloat(context, *value, out);
+Iterator WriteFloat(WriteCtx& ctx, const At<T>& value, Iterator out) {
+  return WriteFloat(ctx, *value, out);
 }
 
 template <typename Iterator, typename T>
-Iterator WriteNat(WriteContext& context, T value, Iterator out) {
-  return Write(context, string_view{NatToStr<T>(value, context.base)}, out);
+Iterator WriteNat(WriteCtx& ctx, T value, Iterator out) {
+  return Write(ctx, string_view{NatToStr<T>(value, ctx.base)}, out);
 }
 
 template <typename Iterator, typename T>
-Iterator WriteInt(WriteContext& context, T value, Iterator out) {
-  return Write(context, string_view{IntToStr<T>(value, context.base)}, out);
+Iterator WriteInt(WriteCtx& ctx, T value, Iterator out) {
+  return Write(ctx, string_view{IntToStr<T>(value, ctx.base)}, out);
 }
 
 template <typename Iterator, typename T >
-Iterator WriteFloat(WriteContext& context, T value, Iterator out) {
-  return Write(context, string_view{FloatToStr<T>(value, context.base)}, out);
+Iterator WriteFloat(WriteCtx& ctx, T value, Iterator out) {
+  return Write(ctx, string_view{FloatToStr<T>(value, ctx.base)}, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, Var value, Iterator out) {
+Iterator Write(WriteCtx& ctx, Var value, Iterator out) {
   if (value.is_index()) {
-    return WriteNat(context, value.index(), out);
+    return WriteNat(ctx, value.index(), out);
   } else {
-    return Write(context, value.name(), out);
+    return Write(ctx, value.name(), out);
   }
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const VarList& values, Iterator out) {
-  return WriteVector(context, values, out);
+Iterator Write(WriteCtx& ctx, const VarList& values, Iterator out) {
+  return WriteVector(ctx, values, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Text& value, Iterator out) {
-  return Write(context, value.text, out);
+Iterator Write(WriteCtx& ctx, const Text& value, Iterator out) {
+  return Write(ctx, value.text, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const TextList& values, Iterator out) {
-  return WriteVector(context, values, out);
+Iterator Write(WriteCtx& ctx, const TextList& values, Iterator out) {
+  return WriteVector(ctx, values, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const ValueType& value, Iterator out) {
-  return WriteFormat(context, value, out);
+Iterator Write(WriteCtx& ctx, const ValueType& value, Iterator out) {
+  return WriteFormat(ctx, value, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const ValueTypeList& values,
-               Iterator out) {
-  return WriteVector(context, values, out);
+Iterator Write(WriteCtx& ctx, const ValueTypeList& values, Iterator out) {
+  return WriteVector(ctx, values, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
+Iterator Write(WriteCtx& ctx,
                const ValueTypeList& values,
                string_view name,
                Iterator out) {
   if (!values.empty()) {
-    out = WriteLpar(context, name, out);
-    out = Write(context, values, out);
-    out = WriteRpar(context, out);
+    out = WriteLpar(ctx, name, out);
+    out = Write(ctx, values, out);
+    out = WriteRpar(ctx, out);
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const StorageType& value, Iterator out) {
-  return WriteFormat(context, value, out);
+Iterator Write(WriteCtx& ctx, const StorageType& value, Iterator out) {
+  return WriteFormat(ctx, value, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const FieldType& value, Iterator out) {
-  out = WriteLpar(context, "field", out);
-  out = Write(context, value.name, out);
+Iterator Write(WriteCtx& ctx, const FieldType& value, Iterator out) {
+  out = WriteLpar(ctx, "field", out);
+  out = Write(ctx, value.name, out);
 
   if (value.mut == Mutability::Var) {
-    out = WriteLpar(context, "mut", out);
+    out = WriteLpar(ctx, "mut", out);
   }
-  out = Write(context, value.type, out);
+  out = Write(ctx, value.type, out);
   if (value.mut == Mutability::Var) {
-    out = WriteRpar(context, out);
+    out = WriteRpar(ctx, out);
   }
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const FieldTypeList& values,
-               Iterator out) {
+Iterator Write(WriteCtx& ctx, const FieldTypeList& values, Iterator out) {
   bool first = true;
   bool prev_has_name = false;
   for (auto& value : values) {
     bool has_name = value->name.has_value();
     if ((has_name || prev_has_name) && !first) {
-      out = WriteRpar(context, out);
+      out = WriteRpar(ctx, out);
     }
     if (has_name || prev_has_name || first) {
-      out = WriteLpar(context, "field", out);
+      out = WriteLpar(ctx, "field", out);
     }
     if (has_name) {
-      out = Write(context, value->name, out);
+      out = Write(ctx, value->name, out);
     }
 
     if (value->mut == Mutability::Var) {
-      out = WriteLpar(context, "mut", out);
+      out = WriteLpar(ctx, "mut", out);
     }
-    out = Write(context, value->type, out);
+    out = Write(ctx, value->type, out);
     if (value->mut == Mutability::Var) {
-      out = WriteRpar(context, out);
+      out = WriteRpar(ctx, out);
     }
 
     prev_has_name = has_name;
     first = false;
   }
   if (!values.empty()) {
-    out = WriteRpar(context, out);
+    out = WriteRpar(ctx, out);
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const StructType& value, Iterator out) {
-  out = WriteLpar(context, "struct", out);
-  out = Write(context, value.fields, out);
-  out = WriteRpar(context, out);
+Iterator Write(WriteCtx& ctx, const StructType& value, Iterator out) {
+  out = WriteLpar(ctx, "struct", out);
+  out = Write(ctx, value.fields, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const ArrayType& value, Iterator out) {
-  out = WriteLpar(context, "array", out);
-  out = Write(context, value.field, out);
-  out = WriteRpar(context, out);
+Iterator Write(WriteCtx& ctx, const ArrayType& value, Iterator out) {
+  out = WriteLpar(ctx, "array", out);
+  out = Write(ctx, value.field, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const FunctionType& value, Iterator out) {
-  out = Write(context, value.params, "param", out);
-  out = Write(context, value.results, "result", out);
+Iterator Write(WriteCtx& ctx, const FunctionType& value, Iterator out) {
+  out = Write(ctx, value.params, "param", out);
+  out = Write(ctx, value.results, "result", out);
   return out;
 }
 
 template <typename Iterator>
-Iterator WriteTypeUse(WriteContext& context,
-                      const OptAt<Var>& value,
-                      Iterator out) {
+Iterator WriteTypeUse(WriteCtx& ctx, const OptAt<Var>& value, Iterator out) {
   if (value) {
-    out = WriteLpar(context, "type", out);
-    out = Write(context, value->value(), out);
-    out = WriteRpar(context, out);
+    out = WriteLpar(ctx, "type", out);
+    out = Write(ctx, value->value(), out);
+    out = WriteRpar(ctx, out);
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const FunctionTypeUse& value,
-               Iterator out) {
-  out = WriteTypeUse(context, value.type_use, out);
-  out = Write(context, *value.type, out);
+Iterator Write(WriteCtx& ctx, const FunctionTypeUse& value, Iterator out) {
+  out = WriteTypeUse(ctx, value.type_use, out);
+  out = Write(ctx, *value.type, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const v128& value, Iterator out) {
+Iterator Write(WriteCtx& ctx, const v128& value, Iterator out) {
   u32x4 immediate = value.as<u32x4>();
-  out = Write(context, "i32x4"_sv, out);
+  out = Write(ctx, "i32x4"_sv, out);
   for (auto& lane : immediate) {
-    out = WriteInt(context, lane, out);
+    out = WriteInt(ctx, lane, out);
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const BlockImmediate& value,
-               Iterator out) {
-  out = Write(context, value.label, out);
-  out = Write(context, value.type, out);
+Iterator Write(WriteCtx& ctx, const BlockImmediate& value, Iterator out) {
+  out = Write(ctx, value.label, out);
+  out = Write(ctx, value.type, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const HeapType2Immediate& value,
-               Iterator out) {
-  out = Write(context, *value.parent, out);
-  out = Write(context, *value.child, out);
+Iterator Write(WriteCtx& ctx, const HeapType2Immediate& value, Iterator out) {
+  out = Write(ctx, *value.parent, out);
+  out = Write(ctx, *value.child, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const BrOnCastImmediate& value,
-               Iterator out) {
-  out = Write(context, *value.target, out);
-  out = Write(context, value.types, out);
+Iterator Write(WriteCtx& ctx, const BrOnCastImmediate& value, Iterator out) {
+  out = Write(ctx, *value.target, out);
+  out = Write(ctx, value.types, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const BrOnExnImmediate& value,
-               Iterator out) {
-  out = Write(context, *value.target, out);
-  out = Write(context, *value.event, out);
+Iterator Write(WriteCtx& ctx, const BrOnExnImmediate& value, Iterator out) {
+  out = Write(ctx, *value.target, out);
+  out = Write(ctx, *value.event, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const BrTableImmediate& value,
-               Iterator out) {
-  out = Write(context, value.targets, out);
-  out = Write(context, *value.default_target, out);
+Iterator Write(WriteCtx& ctx, const BrTableImmediate& value, Iterator out) {
+  out = Write(ctx, value.targets, out);
+  out = Write(ctx, *value.default_target, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
+Iterator Write(WriteCtx& ctx,
                const CallIndirectImmediate& value,
                Iterator out) {
-  out = Write(context, value.table, out);
-  out = Write(context, value.type, out);
+  out = Write(ctx, value.table, out);
+  out = Write(ctx, value.type, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const CopyImmediate& value,
-               Iterator out) {
-  out = Write(context, value.dst, out);
-  out = Write(context, value.src, out);
+Iterator Write(WriteCtx& ctx, const CopyImmediate& value, Iterator out) {
+  out = Write(ctx, value.dst, out);
+  out = Write(ctx, value.src, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const InitImmediate& value,
-               Iterator out) {
-  // Write dcontext, out, st first, if it exists.
+Iterator Write(WriteCtx& ctx, const InitImmediate& value, Iterator out) {
+  // Write dst first, if it exists.
   if (value.dst) {
-    out = Write(context, value.dst->value(), out);
+    out = Write(ctx, value.dst->value(), out);
   }
-  out = Write(context, *value.segment, out);
+  out = Write(ctx, *value.segment, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const LetImmediate& value,
-               Iterator out) {
-  out = Write(context, value.block, out);
-  out = Write(context, value.locals, "local", out);
+Iterator Write(WriteCtx& ctx, const LetImmediate& value, Iterator out) {
+  out = Write(ctx, value.block, out);
+  out = Write(ctx, value.locals, "local", out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const MemArgImmediate& value,
-               Iterator out) {
+Iterator Write(WriteCtx& ctx, const MemArgImmediate& value, Iterator out) {
   if (value.offset) {
-    out = Write(context, "offset="_sv, out);
-    context.ClearSeparator();
-    out = WriteNat(context, value.offset->value(), out);
+    out = Write(ctx, "offset="_sv, out);
+    ctx.ClearSeparator();
+    out = WriteNat(ctx, value.offset->value(), out);
   }
 
   if (value.align) {
-    out = Write(context, "align="_sv, out);
-    context.ClearSeparator();
-    out = WriteNat(context, value.align->value(), out);
+    out = Write(ctx, "align="_sv, out);
+    ctx.ClearSeparator();
+    out = WriteNat(ctx, value.align->value(), out);
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const RttSubImmediate& value,
-               Iterator out) {
-  out = WriteNat(context, *value.depth, out);
-  out = Write(context, value.types, out);
+Iterator Write(WriteCtx& ctx, const RttSubImmediate& value, Iterator out) {
+  out = WriteNat(ctx, *value.depth, out);
+  out = Write(ctx, value.types, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const ShuffleImmediate& value,
-               Iterator out) {
+Iterator Write(WriteCtx& ctx, const ShuffleImmediate& value, Iterator out) {
   for (auto& lane : value) {
-    out = WriteNat(context, lane, out);
+    out = WriteNat(ctx, lane, out);
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const StructFieldImmediate& value,
-               Iterator out) {
-  out = Write(context, *value.struct_, out);
-  out = Write(context, *value.field, out);
+Iterator Write(WriteCtx& ctx, const StructFieldImmediate& value, Iterator out) {
+  out = Write(ctx, *value.struct_, out);
+  out = Write(ctx, *value.field, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Opcode& value, Iterator out) {
-  return WriteFormat(context, value, out);
+Iterator Write(WriteCtx& ctx, const Opcode& value, Iterator out) {
+  return WriteFormat(ctx, value, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Instruction& value, Iterator out) {
-  out = Write(context, *value.opcode, out);
+Iterator Write(WriteCtx& ctx, const Instruction& value, Iterator out) {
+  out = Write(ctx, *value.opcode, out);
 
   switch (value.kind()) {
     case InstructionKind::None:
       break;
 
     case InstructionKind::S32:
-      out = WriteInt(context, value.s32_immediate(), out);
+      out = WriteInt(ctx, value.s32_immediate(), out);
       break;
 
     case InstructionKind::S64:
-      out = WriteInt(context, value.s64_immediate(), out);
+      out = WriteInt(ctx, value.s64_immediate(), out);
       break;
 
     case InstructionKind::F32:
-      out = WriteFloat(context, value.f32_immediate(), out);
+      out = WriteFloat(ctx, value.f32_immediate(), out);
       break;
 
     case InstructionKind::F64:
-      out = WriteFloat(context, value.f64_immediate(), out);
+      out = WriteFloat(ctx, value.f64_immediate(), out);
       break;
 
     case InstructionKind::V128:
-      out = Write(context, value.v128_immediate(), out);
+      out = Write(ctx, value.v128_immediate(), out);
       break;
 
     case InstructionKind::Var:
-      out = Write(context, value.var_immediate(), out);
+      out = Write(ctx, value.var_immediate(), out);
       break;
 
     case InstructionKind::Block:
-      out = Write(context, value.block_immediate(), out);
+      out = Write(ctx, value.block_immediate(), out);
       break;
 
     case InstructionKind::BrOnExn:
-      out = Write(context, value.br_on_exn_immediate(), out);
+      out = Write(ctx, value.br_on_exn_immediate(), out);
       break;
 
     case InstructionKind::BrTable:
-      out = Write(context, value.br_table_immediate(), out);
+      out = Write(ctx, value.br_table_immediate(), out);
       break;
 
     case InstructionKind::CallIndirect:
-      out = Write(context, value.call_indirect_immediate(), out);
+      out = Write(ctx, value.call_indirect_immediate(), out);
       break;
 
     case InstructionKind::Copy:
-      out = Write(context, value.copy_immediate(), out);
+      out = Write(ctx, value.copy_immediate(), out);
       break;
 
     case InstructionKind::Init:
-      out = Write(context, value.init_immediate(), out);
+      out = Write(ctx, value.init_immediate(), out);
       break;
 
     case InstructionKind::Let:
-      out = Write(context, value.let_immediate(), out);
+      out = Write(ctx, value.let_immediate(), out);
       break;
 
     case InstructionKind::MemArg:
-      out = Write(context, value.mem_arg_immediate(), out);
+      out = Write(ctx, value.mem_arg_immediate(), out);
       break;
 
     case InstructionKind::HeapType:
-      out = Write(context, value.heap_type_immediate(), out);
+      out = Write(ctx, value.heap_type_immediate(), out);
       break;
 
     case InstructionKind::Select:
-      out = Write(context, value.select_immediate(), out);
+      out = Write(ctx, value.select_immediate(), out);
       break;
 
     case InstructionKind::Shuffle:
-      out = Write(context, value.shuffle_immediate(), out);
+      out = Write(ctx, value.shuffle_immediate(), out);
       break;
 
     case InstructionKind::SimdLane:
-      out = WriteNat(context, value.simd_lane_immediate(), out);
+      out = WriteNat(ctx, value.simd_lane_immediate(), out);
       break;
 
     case InstructionKind::FuncBind:
-      out = Write(context, value.func_bind_immediate(), out);
+      out = Write(ctx, value.func_bind_immediate(), out);
       break;
 
     case InstructionKind::BrOnCast:
-      out = Write(context, value.br_on_cast_immediate(), out);
+      out = Write(ctx, value.br_on_cast_immediate(), out);
       break;
 
     case InstructionKind::HeapType2:
-      out = Write(context, value.heap_type_2_immediate(), out);
+      out = Write(ctx, value.heap_type_2_immediate(), out);
       break;
 
     case InstructionKind::RttSub:
-      out = Write(context, value.rtt_sub_immediate(), out);
+      out = Write(ctx, value.rtt_sub_immediate(), out);
       break;
 
     case InstructionKind::StructField:
-      out = Write(context, value.struct_field_immediate(), out);
+      out = Write(ctx, value.struct_field_immediate(), out);
       break;
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const InstructionList& values,
-               Iterator out) {
-  return WriteVector(context, values, out);
+Iterator Write(WriteCtx& ctx, const InstructionList& values, Iterator out) {
+  return WriteVector(ctx, values, out);
 }
 
 template <typename Iterator>
-Iterator WriteWithNewlines(WriteContext& context,
+Iterator WriteWithNewlines(WriteCtx& ctx,
                            const InstructionList& values,
                            Iterator out) {
   // If the instruction list ends with and `end` instruction, don't write it
@@ -600,32 +561,30 @@ Iterator WriteWithNewlines(WriteContext& context,
     auto opcode = instr->opcode;
     if (opcode == Opcode::End || opcode == Opcode::Else ||
         opcode == Opcode::Catch) {
-      context.DedentNoToplevel();
-      context.Newline();
+      ctx.DedentNoToplevel();
+      ctx.Newline();
     }
 
-    out = Write(context, instr, out);
+    out = Write(ctx, instr, out);
 
     if (instr->has_block_immediate() || opcode == Opcode::Else ||
         opcode == Opcode::Catch) {
-      context.Indent();
+      ctx.Indent();
     }
-    context.Newline();
+    ctx.Newline();
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const BoundValueType& value,
-               Iterator out) {
-  out = Write(context, value.name, out);
-  out = Write(context, value.type, out);
+Iterator Write(WriteCtx& ctx, const BoundValueType& value, Iterator out) {
+  out = Write(ctx, value.name, out);
+  out = Write(ctx, value.type, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
+Iterator Write(WriteCtx& ctx,
                const BoundValueTypeList& values,
                string_view prefix,
                Iterator out) {
@@ -634,498 +593,484 @@ Iterator Write(WriteContext& context,
   for (auto& value : values) {
     bool has_name = value->name.has_value();
     if ((has_name || prev_has_name) && !first) {
-      out = WriteRpar(context, out);
+      out = WriteRpar(ctx, out);
     }
     if (has_name || prev_has_name || first) {
-      out = WriteLpar(context, prefix, out);
+      out = WriteLpar(ctx, prefix, out);
     }
     if (has_name) {
-      out = Write(context, value->name, out);
+      out = Write(ctx, value->name, out);
     }
-    out = Write(context, value->type, out);
+    out = Write(ctx, value->type, out);
     prev_has_name = has_name;
     first = false;
   }
   if (!values.empty()) {
-    out = WriteRpar(context, out);
+    out = WriteRpar(ctx, out);
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const BoundFunctionType& value,
-               Iterator out) {
-  out = Write(context, value.params, "param", out);
-  out = Write(context, value.results, "result", out);
+Iterator Write(WriteCtx& ctx, const BoundFunctionType& value, Iterator out) {
+  out = Write(ctx, value.params, "param", out);
+  out = Write(ctx, value.results, "result", out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const DefinedType& value, Iterator out) {
-  out = WriteLpar(context, "type", out);
-  out = Write(context, value.name, out);
+Iterator Write(WriteCtx& ctx, const DefinedType& value, Iterator out) {
+  out = WriteLpar(ctx, "type", out);
+  out = Write(ctx, value.name, out);
   if (value.is_function_type()) {
-    out = WriteLpar(context, "func", out);
-    out = Write(context, value.function_type(), out);
-    out = WriteRpar(context, out);
+    out = WriteLpar(ctx, "func", out);
+    out = Write(ctx, value.function_type(), out);
+    out = WriteRpar(ctx, out);
   } else if (value.is_struct_type()) {
-    out = Write(context, value.struct_type(), out);
+    out = Write(ctx, value.struct_type(), out);
   } else {
     assert(value.is_array_type());
-    out = Write(context, value.array_type(), out);
+    out = Write(ctx, value.array_type(), out);
   }
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const FunctionDesc& value, Iterator out) {
-  out = Write(context, "func"_sv, out);
-  out = Write(context, value.name, out);
-  out = WriteTypeUse(context, value.type_use, out);
-  out = Write(context, value.type, out);
+Iterator Write(WriteCtx& ctx, const FunctionDesc& value, Iterator out) {
+  out = Write(ctx, "func"_sv, out);
+  out = Write(ctx, value.name, out);
+  out = WriteTypeUse(ctx, value.type_use, out);
+  out = Write(ctx, value.type, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Limits& value, Iterator out) {
+Iterator Write(WriteCtx& ctx, const Limits& value, Iterator out) {
   if (value.index_type == IndexType::I64) {
-    out = Write(context, "i64"_sv, out);
+    out = Write(ctx, "i64"_sv, out);
   }
-  out = WriteNat(context, value.min, out);
+  out = WriteNat(ctx, value.min, out);
   if (value.max) {
-    out = WriteNat(context, *value.max, out);
+    out = WriteNat(ctx, *value.max, out);
   }
   if (value.shared == Shared::Yes) {
-    out = Write(context, "shared"_sv, out);
+    out = Write(ctx, "shared"_sv, out);
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, HeapType value, Iterator out) {
-  return WriteFormat(context, value, out);
+Iterator Write(WriteCtx& ctx, HeapType value, Iterator out) {
+  return WriteFormat(ctx, value, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, ReferenceType value, Iterator out) {
-  return WriteFormat(context, value, out);
+Iterator Write(WriteCtx& ctx, ReferenceType value, Iterator out) {
+  return WriteFormat(ctx, value, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Rtt& value, Iterator out) {
-  out = WriteLpar(context, "rtt", out);
-  out = WriteNat(context, value.depth, out);
-  out = Write(context, value.type, out);
-  out = WriteRpar(context, out);
+Iterator Write(WriteCtx& ctx, const Rtt& value, Iterator out) {
+  out = WriteLpar(ctx, "rtt", out);
+  out = WriteNat(ctx, value.depth, out);
+  out = Write(ctx, value.type, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const TableType& value, Iterator out) {
-  out = Write(context, value.limits, out);
-  out = WriteFormat(context, value.elemtype, out);
+Iterator Write(WriteCtx& ctx, const TableType& value, Iterator out) {
+  out = Write(ctx, value.limits, out);
+  out = WriteFormat(ctx, value.elemtype, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const TableDesc& value, Iterator out) {
-  out = Write(context, "table"_sv, out);
-  out = Write(context, value.name, out);
-  out = Write(context, value.type, out);
+Iterator Write(WriteCtx& ctx, const TableDesc& value, Iterator out) {
+  out = Write(ctx, "table"_sv, out);
+  out = Write(ctx, value.name, out);
+  out = Write(ctx, value.type, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const MemoryType& value, Iterator out) {
-  out = Write(context, value.limits, out);
+Iterator Write(WriteCtx& ctx, const MemoryType& value, Iterator out) {
+  out = Write(ctx, value.limits, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const MemoryDesc& value, Iterator out) {
-  out = Write(context, "memory"_sv, out);
-  out = Write(context, value.name, out);
-  out = Write(context, value.type, out);
+Iterator Write(WriteCtx& ctx, const MemoryDesc& value, Iterator out) {
+  out = Write(ctx, "memory"_sv, out);
+  out = Write(ctx, value.name, out);
+  out = Write(ctx, value.type, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const GlobalType& value, Iterator out) {
+Iterator Write(WriteCtx& ctx, const GlobalType& value, Iterator out) {
   if (value.mut == Mutability::Var) {
-    out = WriteLpar(context, "mut", out);
+    out = WriteLpar(ctx, "mut", out);
   }
-  out = Write(context, value.valtype, out);
+  out = Write(ctx, value.valtype, out);
   if (value.mut == Mutability::Var) {
-    out = WriteRpar(context, out);
+    out = WriteRpar(ctx, out);
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const GlobalDesc& value, Iterator out) {
-  out = Write(context, "global"_sv, out);
-  out = Write(context, value.name, out);
-  out = Write(context, value.type, out);
+Iterator Write(WriteCtx& ctx, const GlobalDesc& value, Iterator out) {
+  out = Write(ctx, "global"_sv, out);
+  out = Write(ctx, value.name, out);
+  out = Write(ctx, value.type, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const EventType& value, Iterator out) {
-  out = Write(context, value.type, out);
+Iterator Write(WriteCtx& ctx, const EventType& value, Iterator out) {
+  out = Write(ctx, value.type, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const EventDesc& value, Iterator out) {
-  out = Write(context, "event"_sv, out);
-  out = Write(context, value.name, out);
-  out = Write(context, value.type, out);
+Iterator Write(WriteCtx& ctx, const EventDesc& value, Iterator out) {
+  out = Write(ctx, "event"_sv, out);
+  out = Write(ctx, value.name, out);
+  out = Write(ctx, value.type, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Import& value, Iterator out) {
-  out = WriteLpar(context, "import"_sv, out);
-  out = Write(context, value.module, out);
-  out = Write(context, value.name, out);
-  out = WriteLpar(context, out);
+Iterator Write(WriteCtx& ctx, const Import& value, Iterator out) {
+  out = WriteLpar(ctx, "import"_sv, out);
+  out = Write(ctx, value.module, out);
+  out = Write(ctx, value.name, out);
+  out = WriteLpar(ctx, out);
   switch (value.kind()) {
     case ExternalKind::Function:
-      out = Write(context, value.function_desc(), out);
+      out = Write(ctx, value.function_desc(), out);
       break;
 
     case ExternalKind::Table:
-      out = Write(context, value.table_desc(), out);
+      out = Write(ctx, value.table_desc(), out);
       break;
 
     case ExternalKind::Memory:
-      out = Write(context, value.memory_desc(), out);
+      out = Write(ctx, value.memory_desc(), out);
       break;
 
     case ExternalKind::Global:
-      out = Write(context, value.global_desc(), out);
+      out = Write(ctx, value.global_desc(), out);
       break;
 
     case ExternalKind::Event:
-      out = Write(context, value.event_desc(), out);
+      out = Write(ctx, value.event_desc(), out);
       break;
   }
-  out = WriteRpar(context, out);
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const InlineImport& value, Iterator out) {
-  out = WriteLpar(context, "import"_sv, out);
-  out = Write(context, value.module, out);
-  out = Write(context, value.name, out);
-  out = WriteRpar(context, out);
+Iterator Write(WriteCtx& ctx, const InlineImport& value, Iterator out) {
+  out = WriteLpar(ctx, "import"_sv, out);
+  out = Write(ctx, value.module, out);
+  out = Write(ctx, value.name, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const InlineExport& value, Iterator out) {
-  out = WriteLpar(context, "export"_sv, out);
-  out = Write(context, value.name, out);
-  out = WriteRpar(context, out);
+Iterator Write(WriteCtx& ctx, const InlineExport& value, Iterator out) {
+  out = WriteLpar(ctx, "export"_sv, out);
+  out = Write(ctx, value.name, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const InlineExportList& values,
-               Iterator out) {
-  return WriteVector(context, values, out);
+Iterator Write(WriteCtx& ctx, const InlineExportList& values, Iterator out) {
+  return WriteVector(ctx, values, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Function& value, Iterator out) {
-  out = WriteLpar(context, "func", out);
+Iterator Write(WriteCtx& ctx, const Function& value, Iterator out) {
+  out = WriteLpar(ctx, "func", out);
 
   // Can't write FunctionDesc directly, since inline imports/exports occur
   // between the bindvar and the type use.
-  out = Write(context, value.desc.name, out);
-  out = Write(context, value.exports, out);
+  out = Write(ctx, value.desc.name, out);
+  out = Write(ctx, value.exports, out);
 
   if (value.import) {
-    out = Write(context, *value.import, out);
+    out = Write(ctx, *value.import, out);
   }
 
-  out = WriteTypeUse(context, value.desc.type_use, out);
-  out = Write(context, value.desc.type, out);
+  out = WriteTypeUse(ctx, value.desc.type_use, out);
+  out = Write(ctx, value.desc.type, out);
 
   if (!value.import) {
-    context.Indent();
-    context.Newline();
-    out = Write(context, value.locals, "local", out);
-    context.Newline();
-    out = WriteWithNewlines(context, value.instructions, out);
-    context.Dedent();
+    ctx.Indent();
+    ctx.Newline();
+    out = Write(ctx, value.locals, "local", out);
+    ctx.Newline();
+    out = WriteWithNewlines(ctx, value.instructions, out);
+    ctx.Dedent();
   }
 
-  out = WriteRpar(context, out);
-  context.Newline();
+  out = WriteRpar(ctx, out);
+  ctx.Newline();
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
+Iterator Write(WriteCtx& ctx,
                const ElementExpressionList& elem_exprs,
                Iterator out) {
   // Use spaces instead of newlines for element expressions.
   for (auto& elem_expr : elem_exprs) {
     for (auto& instr : elem_expr->instructions) {
       // Expressions need to be wrapped in parens.
-      out = WriteLpar(context, out);
-      out = Write(context, instr, out);
-      out = WriteRpar(context, out);
-      context.Space();
+      out = WriteLpar(ctx, out);
+      out = Write(ctx, instr, out);
+      out = WriteRpar(ctx, out);
+      ctx.Space();
     }
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
+Iterator Write(WriteCtx& ctx,
                const ElementListWithExpressions& value,
                Iterator out) {
-  out = Write(context, value.elemtype, out);
-  out = Write(context, value.list, out);
+  out = Write(ctx, value.elemtype, out);
+  out = Write(ctx, value.list, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, ExternalKind value, Iterator out) {
-  return WriteFormat(context, value, out);
+Iterator Write(WriteCtx& ctx, ExternalKind value, Iterator out) {
+  return WriteFormat(ctx, value, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const ElementListWithVars& value,
-               Iterator out) {
-  out = Write(context, value.kind, out);
-  out = Write(context, value.list, out);
+Iterator Write(WriteCtx& ctx, const ElementListWithVars& value, Iterator out) {
+  out = Write(ctx, value.kind, out);
+  out = Write(ctx, value.list, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const ElementList& value, Iterator out) {
+Iterator Write(WriteCtx& ctx, const ElementList& value, Iterator out) {
   if (holds_alternative<ElementListWithVars>(value)) {
-    return Write(context, get<ElementListWithVars>(value), out);
+    return Write(ctx, get<ElementListWithVars>(value), out);
   } else {
-    return Write(context, get<ElementListWithExpressions>(value), out);
+    return Write(ctx, get<ElementListWithExpressions>(value), out);
   }
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Table& value, Iterator out) {
-  out = WriteLpar(context, "table", out);
+Iterator Write(WriteCtx& ctx, const Table& value, Iterator out) {
+  out = WriteLpar(ctx, "table", out);
 
   // Can't write TableDesc directly, since inline imports/exports occur after
   // the bind var.
-  out = Write(context, value.desc.name, out);
-  out = Write(context, value.exports, out);
+  out = Write(ctx, value.desc.name, out);
+  out = Write(ctx, value.exports, out);
 
   if (value.import) {
-    out = Write(context, *value.import, out);
-    out = Write(context, value.desc.type, out);
+    out = Write(ctx, *value.import, out);
+    out = Write(ctx, value.desc.type, out);
   } else if (value.elements) {
     // Don't write the limits, because they are implicitly defined by the
     // element segment length.
-    out = Write(context, value.desc.type->elemtype, out);
-    out = WriteLpar(context, "elem", out);
+    out = Write(ctx, value.desc.type->elemtype, out);
+    out = WriteLpar(ctx, "elem", out);
     // Only write the list of elements, without the ExternalKind or
     // ReferenceType.
     if (holds_alternative<ElementListWithVars>(*value.elements)) {
-      out = Write(context, get<ElementListWithVars>(*value.elements).list, out);
+      out = Write(ctx, get<ElementListWithVars>(*value.elements).list, out);
     } else {
-      out = Write(context,
+      out = Write(ctx,
                   get<ElementListWithExpressions>(*value.elements).list, out);
     }
-    out = WriteRpar(context, out);
+    out = WriteRpar(ctx, out);
   } else {
-    out = Write(context, value.desc.type, out);
+    out = Write(ctx, value.desc.type, out);
   }
 
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename T, typename Iterator>
-Iterator WriteNumericValues(WriteContext& context,
+Iterator WriteNumericValues(WriteCtx& ctx,
                             const NumericData& value,
                             Iterator out) {
   for (Index i = 0; i < value.count(); ++i) {
     if constexpr (std::is_same_v<T, v128>) {
-      out = Write(context, value.value<T>(i), out);
+      out = Write(ctx, value.value<T>(i), out);
     } else if constexpr (std::is_floating_point_v<T>) {
-      out = WriteFloat(context, value.value<T>(i), out);
+      out = WriteFloat(ctx, value.value<T>(i), out);
     } else {
-      out = WriteInt(context, value.value<T>(i), out);
+      out = WriteInt(ctx, value.value<T>(i), out);
     }
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const NumericData& value, Iterator out) {
+Iterator Write(WriteCtx& ctx, const NumericData& value, Iterator out) {
   switch (value.type) {
     case NumericDataType::I8:
-      out = WriteLpar(context, "i8", out);
-      out = WriteNumericValues<s8>(context, value, out);
+      out = WriteLpar(ctx, "i8", out);
+      out = WriteNumericValues<s8>(ctx, value, out);
       break;
 
     case NumericDataType::I16:
-      out = WriteLpar(context, "i16", out);
-      out = WriteNumericValues<s16>(context, value, out);
+      out = WriteLpar(ctx, "i16", out);
+      out = WriteNumericValues<s16>(ctx, value, out);
       break;
 
     case NumericDataType::I32:
-      out = WriteLpar(context, "i32", out);
-      out = WriteNumericValues<s32>(context, value, out);
+      out = WriteLpar(ctx, "i32", out);
+      out = WriteNumericValues<s32>(ctx, value, out);
       break;
 
     case NumericDataType::I64:
-      out = WriteLpar(context, "i64", out);
-      out = WriteNumericValues<s64>(context, value, out);
+      out = WriteLpar(ctx, "i64", out);
+      out = WriteNumericValues<s64>(ctx, value, out);
       break;
 
     case NumericDataType::F32:
-      out = WriteLpar(context, "f32", out);
-      out = WriteNumericValues<f32>(context, value, out);
+      out = WriteLpar(ctx, "f32", out);
+      out = WriteNumericValues<f32>(ctx, value, out);
       break;
 
     case NumericDataType::F64:
-      out = WriteLpar(context, "f64", out);
-      out = WriteNumericValues<f64>(context, value, out);
+      out = WriteLpar(ctx, "f64", out);
+      out = WriteNumericValues<f64>(ctx, value, out);
       break;
 
     case NumericDataType::V128:
-      out = WriteLpar(context, "v128", out);
-      out = WriteNumericValues<v128>(context, value, out);
+      out = WriteLpar(ctx, "v128", out);
+      out = WriteNumericValues<v128>(ctx, value, out);
       break;
   }
 
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const DataItem& value, Iterator out) {
+Iterator Write(WriteCtx& ctx, const DataItem& value, Iterator out) {
   if (value.is_text()) {
-    return Write(context, value.text(), out);
+    return Write(ctx, value.text(), out);
   } else {
     assert(value.is_numeric_data());
-    return Write(context, value.numeric_data(), out);
+    return Write(ctx, value.numeric_data(), out);
   }
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const DataItemList& values,
-               Iterator out) {
-  return WriteVector(context, values, out);
+Iterator Write(WriteCtx& ctx, const DataItemList& values, Iterator out) {
+  return WriteVector(ctx, values, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Memory& value, Iterator out) {
-  out = WriteLpar(context, "memory", out);
+Iterator Write(WriteCtx& ctx, const Memory& value, Iterator out) {
+  out = WriteLpar(ctx, "memory", out);
 
   // Can't write MemoryDesc directly, since inline imports/exports occur after
   // the bind var.
-  out = Write(context, value.desc.name, out);
-  out = Write(context, value.exports, out);
+  out = Write(ctx, value.desc.name, out);
+  out = Write(ctx, value.exports, out);
 
   if (value.import) {
-    out = Write(context, *value.import, out);
-    out = Write(context, value.desc.type, out);
+    out = Write(ctx, *value.import, out);
+    out = Write(ctx, value.desc.type, out);
   } else if (value.data) {
-    out = WriteLpar(context, "data", out);
-    out = Write(context, value.data, out);
-    out = WriteRpar(context, out);
+    out = WriteLpar(ctx, "data", out);
+    out = Write(ctx, value.data, out);
+    out = WriteRpar(ctx, out);
   } else {
-    out = Write(context, value.desc.type, out);
+    out = Write(ctx, value.desc.type, out);
   }
 
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const ConstantExpression& value,
-               Iterator out) {
-  return Write(context, value.instructions, out);
+Iterator Write(WriteCtx& ctx, const ConstantExpression& value, Iterator out) {
+  return Write(ctx, value.instructions, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Global& value, Iterator out) {
-  out = WriteLpar(context, "global", out);
+Iterator Write(WriteCtx& ctx, const Global& value, Iterator out) {
+  out = WriteLpar(ctx, "global", out);
 
   // Can't write GlobalDesc directly, since inline imports/exports occur after
   // the bind var.
-  out = Write(context, value.desc.name, out);
-  out = Write(context, value.exports, out);
+  out = Write(ctx, value.desc.name, out);
+  out = Write(ctx, value.exports, out);
 
   if (value.import) {
-    out = Write(context, *value.import, out);
-    out = Write(context, value.desc.type, out);
+    out = Write(ctx, *value.import, out);
+    out = Write(ctx, value.desc.type, out);
   } else {
-    out = Write(context, value.desc.type, out);
-    out = Write(context, value.init, out);
+    out = Write(ctx, value.desc.type, out);
+    out = Write(ctx, value.init, out);
   }
 
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Export& value, Iterator out) {
-  out = WriteLpar(context, "export", out);
-  out = Write(context, value.name, out);
-  out = WriteLpar(context, out);
-  out = Write(context, value.kind, out);
-  out = Write(context, value.var, out);
-  out = WriteRpar(context, out);
-  out = WriteRpar(context, out);
+Iterator Write(WriteCtx& ctx, const Export& value, Iterator out) {
+  out = WriteLpar(ctx, "export", out);
+  out = Write(ctx, value.name, out);
+  out = WriteLpar(ctx, out);
+  out = Write(ctx, value.kind, out);
+  out = Write(ctx, value.var, out);
+  out = WriteRpar(ctx, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Start& value, Iterator out) {
-  out = WriteLpar(context, "start", out);
-  out = Write(context, value.var, out);
-  out = WriteRpar(context, out);
+Iterator Write(WriteCtx& ctx, const Start& value, Iterator out) {
+  out = WriteLpar(ctx, "start", out);
+  out = Write(ctx, value.var, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const ElementExpression& value,
-               Iterator out) {
-  return Write(context, value.instructions, out);
+Iterator Write(WriteCtx& ctx, const ElementExpression& value, Iterator out) {
+  return Write(ctx, value.instructions, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const ElementSegment& value,
-               Iterator out) {
-  out = WriteLpar(context, "elem", out);
-  out = Write(context, value.name, out);
+Iterator Write(WriteCtx& ctx, const ElementSegment& value, Iterator out) {
+  out = WriteLpar(ctx, "elem", out);
+  out = Write(ctx, value.name, out);
   switch (value.type) {
     case SegmentType::Active:
       if (value.table) {
-        out = WriteLpar(context, "table", out);
-        out = Write(context, *value.table, out);
-        out = WriteRpar(context, out);
+        out = WriteLpar(ctx, "table", out);
+        out = Write(ctx, *value.table, out);
+        out = WriteRpar(ctx, out);
       }
       if (value.offset) {
-        out = WriteLpar(context, "offset", out);
-        out = Write(context, *value.offset, out);
-        out = WriteRpar(context, out);
+        out = WriteLpar(ctx, "offset", out);
+        out = Write(ctx, *value.offset, out);
+        out = WriteRpar(ctx, out);
       }
 
       // When writing a function var list, we can omit the "func" keyword to
@@ -1136,442 +1081,431 @@ Iterator Write(WriteContext& context,
         //  the "table use" or bind_var syntax.
         if (element_vars.kind != ExternalKind::Function || value.table ||
             value.name) {
-          out = Write(context, element_vars.kind, out);
+          out = Write(ctx, element_vars.kind, out);
         }
-        out = Write(context, element_vars.list, out);
+        out = Write(ctx, element_vars.list, out);
       } else {
-        out = Write(context,
-                    get<ElementListWithExpressions>(value.elements), out);
+        out = Write(ctx, get<ElementListWithExpressions>(value.elements), out);
       }
       break;
 
     case SegmentType::Passive:
-      out = Write(context, value.elements, out);
+      out = Write(ctx, value.elements, out);
       break;
 
     case SegmentType::Declared:
-      out = Write(context, "declare"_sv, out);
-      out = Write(context, value.elements, out);
+      out = Write(ctx, "declare"_sv, out);
+      out = Write(ctx, value.elements, out);
       break;
   }
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const DataSegment& value, Iterator out) {
-  out = WriteLpar(context, "data", out);
-  out = Write(context, value.name, out);
+Iterator Write(WriteCtx& ctx, const DataSegment& value, Iterator out) {
+  out = WriteLpar(ctx, "data", out);
+  out = Write(ctx, value.name, out);
   if (value.type == SegmentType::Active) {
     if (value.memory) {
-      out = WriteLpar(context, "memory", out);
-      out = Write(context, *value.memory, out);
-      out = WriteRpar(context, out);
+      out = WriteLpar(ctx, "memory", out);
+      out = Write(ctx, *value.memory, out);
+      out = WriteRpar(ctx, out);
     }
     if (value.offset) {
-      out = WriteLpar(context, "offset", out);
-      out = Write(context, *value.offset, out);
-      out = WriteRpar(context, out);
+      out = WriteLpar(ctx, "offset", out);
+      out = Write(ctx, *value.offset, out);
+      out = WriteRpar(ctx, out);
     }
   }
 
-  out = Write(context, value.data, out);
-  out = WriteRpar(context, out);
+  out = Write(ctx, value.data, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Event& value, Iterator out) {
-  out = WriteLpar(context, "event", out);
+Iterator Write(WriteCtx& ctx, const Event& value, Iterator out) {
+  out = WriteLpar(ctx, "event", out);
 
   // Can't write EventDesc directly, since inline imports/exports occur after
   // the bind var.
-  out = Write(context, value.desc.name, out);
-  out = Write(context, value.exports, out);
+  out = Write(ctx, value.desc.name, out);
+  out = Write(ctx, value.exports, out);
 
   if (value.import) {
-    out = Write(context, *value.import, out);
-    out = Write(context, value.desc.type, out);
+    out = Write(ctx, *value.import, out);
+    out = Write(ctx, value.desc.type, out);
   } else {
-    out = Write(context, value.desc.type, out);
+    out = Write(ctx, value.desc.type, out);
   }
 
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const ModuleItem& value, Iterator out) {
+Iterator Write(WriteCtx& ctx, const ModuleItem& value, Iterator out) {
   switch (value.kind()) {
     case ModuleItemKind::DefinedType:
-      out = Write(context, value.defined_type(), out);
+      out = Write(ctx, value.defined_type(), out);
       break;
 
     case ModuleItemKind::Import:
-      out = Write(context, value.import(), out);
+      out = Write(ctx, value.import(), out);
       break;
 
     case ModuleItemKind::Function:
-      out = Write(context, value.function(), out);
+      out = Write(ctx, value.function(), out);
       break;
 
     case ModuleItemKind::Table:
-      out = Write(context, value.table(), out);
+      out = Write(ctx, value.table(), out);
       break;
 
     case ModuleItemKind::Memory:
-      out = Write(context, value.memory(), out);
+      out = Write(ctx, value.memory(), out);
       break;
 
     case ModuleItemKind::Global:
-      out = Write(context, value.global(), out);
+      out = Write(ctx, value.global(), out);
       break;
 
     case ModuleItemKind::Export:
-      out = Write(context, value.export_(), out);
+      out = Write(ctx, value.export_(), out);
       break;
 
     case ModuleItemKind::Start:
-      out = Write(context, value.start(), out);
+      out = Write(ctx, value.start(), out);
       break;
 
     case ModuleItemKind::ElementSegment:
-      out = Write(context, value.element_segment(), out);
+      out = Write(ctx, value.element_segment(), out);
       break;
 
     case ModuleItemKind::DataSegment:
-      out = Write(context, value.data_segment(), out);
+      out = Write(ctx, value.data_segment(), out);
       break;
 
     case ModuleItemKind::Event:
-      out = Write(context, value.event(), out);
+      out = Write(ctx, value.event(), out);
       break;
   }
-  context.Newline();
+  ctx.Newline();
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Module& value, Iterator out) {
-  return WriteVector(context, value, out);
+Iterator Write(WriteCtx& ctx, const Module& value, Iterator out) {
+  return WriteVector(ctx, value, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const ScriptModule& value, Iterator out) {
-  out = WriteLpar(context, "module", out);
-  out = Write(context, value.name, out);
+Iterator Write(WriteCtx& ctx, const ScriptModule& value, Iterator out) {
+  out = WriteLpar(ctx, "module", out);
+  out = Write(ctx, value.name, out);
   switch (value.kind) {
     case ScriptModuleKind::Text:
-      context.Indent();
-      context.Newline();
-      out = Write(context, value.module(), out);
-      context.Dedent();
+      ctx.Indent();
+      ctx.Newline();
+      out = Write(ctx, value.module(), out);
+      ctx.Dedent();
       break;
 
     case ScriptModuleKind::Binary:
-      out = Write(context, "binary"_sv, out);
-      out = Write(context, value.text_list(), out);
+      out = Write(ctx, "binary"_sv, out);
+      out = Write(ctx, value.text_list(), out);
       break;
 
     case ScriptModuleKind::Quote:
-      out = Write(context, "quote"_sv, out);
-      out = Write(context, value.text_list(), out);
+      out = Write(ctx, "quote"_sv, out);
+      out = Write(ctx, value.text_list(), out);
       break;
   }
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Const& value, Iterator out) {
-  out = WriteLpar(context, out);
+Iterator Write(WriteCtx& ctx, const Const& value, Iterator out) {
+  out = WriteLpar(ctx, out);
   switch (value.kind()) {
     case ConstKind::U32:
-      out = Write(context, Opcode::I32Const, out);
-      out = WriteInt(context, value.u32_(), out);
+      out = Write(ctx, Opcode::I32Const, out);
+      out = WriteInt(ctx, value.u32_(), out);
       break;
 
     case ConstKind::U64:
-      out = Write(context, Opcode::I64Const, out);
-      out = WriteInt(context, value.u64_(), out);
+      out = Write(ctx, Opcode::I64Const, out);
+      out = WriteInt(ctx, value.u64_(), out);
       break;
 
     case ConstKind::F32:
-      out = Write(context, Opcode::F32Const, out);
-      out = WriteFloat(context, value.f32_(), out);
+      out = Write(ctx, Opcode::F32Const, out);
+      out = WriteFloat(ctx, value.f32_(), out);
       break;
 
     case ConstKind::F64:
-      out = Write(context, Opcode::F64Const, out);
-      out = WriteFloat(context, value.f64_(), out);
+      out = Write(ctx, Opcode::F64Const, out);
+      out = WriteFloat(ctx, value.f64_(), out);
       break;
 
     case ConstKind::V128:
-      out = Write(context, Opcode::V128Const, out);
-      out = Write(context, value.v128_(), out);
+      out = Write(ctx, Opcode::V128Const, out);
+      out = Write(ctx, value.v128_(), out);
       break;
 
     case ConstKind::RefNull:
-      out = Write(context, Opcode::RefNull, out);
+      out = Write(ctx, Opcode::RefNull, out);
       break;
 
     case ConstKind::RefExtern:
-      out = Write(context, "ref.extern"_sv, out);
-      out = WriteNat(context, value.ref_extern().var, out);
+      out = Write(ctx, "ref.extern"_sv, out);
+      out = WriteNat(ctx, value.ref_extern().var, out);
       break;
   }
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const ConstList& values, Iterator out) {
-  return WriteVector(context, values, out);
+Iterator Write(WriteCtx& ctx, const ConstList& values, Iterator out) {
+  return WriteVector(ctx, values, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const InvokeAction& value, Iterator out) {
-  out = WriteLpar(context, "invoke", out);
-  out = Write(context, value.module, out);
-  out = Write(context, value.name, out);
-  out = Write(context, value.consts, out);
-  out = WriteRpar(context, out);
+Iterator Write(WriteCtx& ctx, const InvokeAction& value, Iterator out) {
+  out = WriteLpar(ctx, "invoke", out);
+  out = Write(ctx, value.module, out);
+  out = Write(ctx, value.name, out);
+  out = Write(ctx, value.consts, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const GetAction& value, Iterator out) {
-  out = WriteLpar(context, "get", out);
-  out = Write(context, value.module, out);
-  out = Write(context, value.name, out);
-  out = WriteRpar(context, out);
+Iterator Write(WriteCtx& ctx, const GetAction& value, Iterator out) {
+  out = WriteLpar(ctx, "get", out);
+  out = Write(ctx, value.module, out);
+  out = Write(ctx, value.name, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Action& value, Iterator out) {
+Iterator Write(WriteCtx& ctx, const Action& value, Iterator out) {
   if (holds_alternative<InvokeAction>(value)) {
-    out = Write(context, get<InvokeAction>(value), out);
+    out = Write(ctx, get<InvokeAction>(value), out);
   } else if (holds_alternative<GetAction>(value)) {
-    out = Write(context, get<GetAction>(value), out);
+    out = Write(ctx, get<GetAction>(value), out);
   }
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const ModuleAssertion& value,
-               Iterator out) {
-  out = Write(context, value.module, out);
-  context.Newline();
-  out = Write(context, value.message, out);
+Iterator Write(WriteCtx& ctx, const ModuleAssertion& value, Iterator out) {
+  out = Write(ctx, value.module, out);
+  ctx.Newline();
+  out = Write(ctx, value.message, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const ActionAssertion& value,
-               Iterator out) {
-  out = Write(context, value.action, out);
-  out = Write(context, value.message, out);
+Iterator Write(WriteCtx& ctx, const ActionAssertion& value, Iterator out) {
+  out = Write(ctx, value.action, out);
+  out = Write(ctx, value.message, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const NanKind& value, Iterator out) {
+Iterator Write(WriteCtx& ctx, const NanKind& value, Iterator out) {
   if (value == NanKind::Arithmetic) {
-    return Write(context, "nan:arithmetic"_sv, out);
+    return Write(ctx, "nan:arithmetic"_sv, out);
   } else {
     assert(value == NanKind::Canonical);
-    return Write(context, "nan:canonical"_sv, out);
+    return Write(ctx, "nan:canonical"_sv, out);
   }
 }
 
 template <typename Iterator, typename T>
-Iterator Write(WriteContext& context,
-               const FloatResult<T>& value,
-               Iterator out) {
+Iterator Write(WriteCtx& ctx, const FloatResult<T>& value, Iterator out) {
   if (holds_alternative<T>(value)) {
-    return WriteFloat(context, get<T>(value), out);
+    return WriteFloat(ctx, get<T>(value), out);
   } else {
-    return Write(context, get<NanKind>(value), out);
+    return Write(ctx, get<NanKind>(value), out);
   }
 }
 
 template <typename Iterator, typename T, size_t N>
-Iterator Write(WriteContext& context,
+Iterator Write(WriteCtx& ctx,
                const std::array<FloatResult<T>, N>& value,
                Iterator out) {
-  return WriteRange(context, value.begin(), value.end(), out);
+  return WriteRange(ctx, value.begin(), value.end(), out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const ReturnResult& value, Iterator out) {
-  out = WriteLpar(context, out);
+Iterator Write(WriteCtx& ctx, const ReturnResult& value, Iterator out) {
+  out = WriteLpar(ctx, out);
   switch (value.index()) {
     case 0: // u32
-      out = Write(context, Opcode::I32Const, out);
-      out = WriteInt(context, get<u32>(value), out);
+      out = Write(ctx, Opcode::I32Const, out);
+      out = WriteInt(ctx, get<u32>(value), out);
       break;
 
     case 1: // u64
-      out = Write(context, Opcode::I64Const, out);
-      out = WriteInt(context, get<u64>(value), out);
+      out = Write(ctx, Opcode::I64Const, out);
+      out = WriteInt(ctx, get<u64>(value), out);
       break;
 
     case 2: // v128
-      out = Write(context, Opcode::V128Const, out);
-      out = Write(context, get<v128>(value), out);
+      out = Write(ctx, Opcode::V128Const, out);
+      out = Write(ctx, get<v128>(value), out);
       break;
 
     case 3: // F32Result
-      out = Write(context, Opcode::F32Const, out);
-      out = Write(context, get<F32Result>(value), out);
+      out = Write(ctx, Opcode::F32Const, out);
+      out = Write(ctx, get<F32Result>(value), out);
       break;
 
     case 4: // F64Result
-      out = Write(context, Opcode::F64Const, out);
-      out = Write(context, get<F64Result>(value), out);
+      out = Write(ctx, Opcode::F64Const, out);
+      out = Write(ctx, get<F64Result>(value), out);
       break;
 
     case 5: // F32x4Result
-      out = Write(context, Opcode::V128Const, out);
-      out = Write(context, "f32x4"_sv, out);
-      out = Write(context, get<F32x4Result>(value), out);
+      out = Write(ctx, Opcode::V128Const, out);
+      out = Write(ctx, "f32x4"_sv, out);
+      out = Write(ctx, get<F32x4Result>(value), out);
       break;
 
     case 6: // F64x2Result
-      out = Write(context, Opcode::V128Const, out);
-      out = Write(context, "f64x2"_sv, out);
-      out = Write(context, get<F64x2Result>(value), out);
+      out = Write(ctx, Opcode::V128Const, out);
+      out = Write(ctx, "f64x2"_sv, out);
+      out = Write(ctx, get<F64x2Result>(value), out);
       break;
 
     case 7: // RefNullConst
-      out = Write(context, Opcode::RefNull, out);
+      out = Write(ctx, Opcode::RefNull, out);
       break;
 
     case 8: // RefExternConst
-      out = Write(context, "ref.extern"_sv, out);
-      out = WriteNat(context, *get<RefExternConst>(value).var, out);
+      out = Write(ctx, "ref.extern"_sv, out);
+      out = WriteNat(ctx, *get<RefExternConst>(value).var, out);
       break;
 
     case 9: // RefExternResult
-      out = Write(context, "ref.extern"_sv, out);
+      out = Write(ctx, "ref.extern"_sv, out);
       break;
 
     case 10: // RefFuncResult
-      out = Write(context, "ref.func"_sv, out);
+      out = Write(ctx, "ref.func"_sv, out);
       break;
   }
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const ReturnResultList& values,
-               Iterator out) {
-  return WriteVector(context, values, out);
+Iterator Write(WriteCtx& ctx, const ReturnResultList& values, Iterator out) {
+  return WriteVector(ctx, values, out);
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context,
-               const ReturnAssertion& value,
-               Iterator out) {
-  out = Write(context, value.action, out);
-  out = Write(context, value.results, out);
+Iterator Write(WriteCtx& ctx, const ReturnAssertion& value, Iterator out) {
+  out = Write(ctx, value.action, out);
+  out = Write(ctx, value.results, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Assertion& value, Iterator out) {
+Iterator Write(WriteCtx& ctx, const Assertion& value, Iterator out) {
   switch (value.kind) {
     case AssertionKind::Malformed:
-      out = WriteLpar(context, "assert_malformed", out);
-      context.Indent();
-      context.Newline();
-      out = Write(context, get<ModuleAssertion>(value.desc), out);
-      context.Dedent();
+      out = WriteLpar(ctx, "assert_malformed", out);
+      ctx.Indent();
+      ctx.Newline();
+      out = Write(ctx, get<ModuleAssertion>(value.desc), out);
+      ctx.Dedent();
       break;
 
     case AssertionKind::Invalid:
-      out = WriteLpar(context, "assert_invalid", out);
-      context.Indent();
-      context.Newline();
-      out = Write(context, get<ModuleAssertion>(value.desc), out);
-      context.Dedent();
+      out = WriteLpar(ctx, "assert_invalid", out);
+      ctx.Indent();
+      ctx.Newline();
+      out = Write(ctx, get<ModuleAssertion>(value.desc), out);
+      ctx.Dedent();
       break;
 
     case AssertionKind::Unlinkable:
-      out = WriteLpar(context, "assert_unlinkable", out);
-      context.Indent();
-      context.Newline();
-      out = Write(context, get<ModuleAssertion>(value.desc), out);
-      context.Dedent();
+      out = WriteLpar(ctx, "assert_unlinkable", out);
+      ctx.Indent();
+      ctx.Newline();
+      out = Write(ctx, get<ModuleAssertion>(value.desc), out);
+      ctx.Dedent();
       break;
 
     case AssertionKind::ActionTrap:
-      out = WriteLpar(context, "assert_trap", out);
-      out = Write(context, get<ActionAssertion>(value.desc), out);
+      out = WriteLpar(ctx, "assert_trap", out);
+      out = Write(ctx, get<ActionAssertion>(value.desc), out);
       break;
 
     case AssertionKind::Return:
-      out = WriteLpar(context, "assert_return", out);
-      out = Write(context, get<ReturnAssertion>(value.desc), out);
+      out = WriteLpar(ctx, "assert_return", out);
+      out = Write(ctx, get<ReturnAssertion>(value.desc), out);
       break;
 
     case AssertionKind::ModuleTrap:
-      out = WriteLpar(context, "assert_trap", out);
-      context.Indent();
-      context.Newline();
-      out = Write(context, get<ModuleAssertion>(value.desc), out);
-      context.Dedent();
+      out = WriteLpar(ctx, "assert_trap", out);
+      ctx.Indent();
+      ctx.Newline();
+      out = Write(ctx, get<ModuleAssertion>(value.desc), out);
+      ctx.Dedent();
       break;
 
     case AssertionKind::Exhaustion:
-      out = WriteLpar(context, "assert_exhaustion", out);
-      out = Write(context, get<ActionAssertion>(value.desc), out);
+      out = WriteLpar(ctx, "assert_exhaustion", out);
+      out = Write(ctx, get<ActionAssertion>(value.desc), out);
       break;
   }
-  out = WriteRpar(context, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Register& value, Iterator out) {
-  out = WriteLpar(context, "register", out);
-  out = Write(context, value.name, out);
-  out = Write(context, value.module, out);
-  out = WriteRpar(context, out);
+Iterator Write(WriteCtx& ctx, const Register& value, Iterator out) {
+  out = WriteLpar(ctx, "register", out);
+  out = Write(ctx, value.name, out);
+  out = Write(ctx, value.module, out);
+  out = WriteRpar(ctx, out);
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Command& value, Iterator out) {
+Iterator Write(WriteCtx& ctx, const Command& value, Iterator out) {
   switch (value.kind()) {
     case CommandKind::ScriptModule:
-      out = Write(context, value.script_module(), out);
+      out = Write(ctx, value.script_module(), out);
       break;
 
     case CommandKind::Register:
-      out = Write(context, value.register_(), out);
+      out = Write(ctx, value.register_(), out);
       break;
 
     case CommandKind::Action:
-      out = Write(context, value.action(), out);
+      out = Write(ctx, value.action(), out);
       break;
 
     case CommandKind::Assertion:
-      out = Write(context, value.assertion(), out);
+      out = Write(ctx, value.assertion(), out);
       break;
   }
-  context.Newline();
+  ctx.Newline();
   return out;
 }
 
 template <typename Iterator>
-Iterator Write(WriteContext& context, const Script& values, Iterator out) {
-  return WriteVector(context, values, out);
+Iterator Write(WriteCtx& ctx, const Script& values, Iterator out) {
+  return WriteVector(ctx, values, out);
 }
 
 }  // namespace wasp::text

--- a/include/wasp/valid/match.h
+++ b/include/wasp/valid/match.h
@@ -22,85 +22,85 @@
 
 namespace wasp::valid {
 
-struct Context;
+struct ValidCtx;
 
-bool IsSame(Context&,
+bool IsSame(ValidCtx&,
             const binary::HeapType& expected,
             const binary::HeapType& actual);
-bool IsSame(Context&,
+bool IsSame(ValidCtx&,
             const binary::RefType& expected,
             const binary::RefType& actual);
-bool IsSame(Context&,
+bool IsSame(ValidCtx&,
             const binary::ReferenceType& expected,
             const binary::ReferenceType& actual);
-bool IsSame(Context&, const binary::Rtt& expected, const binary::Rtt& actual);
-bool IsSame(Context&,
+bool IsSame(ValidCtx&, const binary::Rtt& expected, const binary::Rtt& actual);
+bool IsSame(ValidCtx&,
             const binary::ValueType& expected,
             const binary::ValueType& actual);
-bool IsSame(Context&,
+bool IsSame(ValidCtx&,
             const binary::ValueTypeList& expected,
             const binary::ValueTypeList& actual);
-bool IsSame(Context&, const StackType& expected, const StackType& actual);
-bool IsSame(Context&, StackTypeSpan expected, StackTypeSpan actual);
-bool IsSame(Context& context,
+bool IsSame(ValidCtx&, const StackType& expected, const StackType& actual);
+bool IsSame(ValidCtx&, StackTypeSpan expected, StackTypeSpan actual);
+bool IsSame(ValidCtx& ctx,
             const binary::StorageType& expected,
             const binary::StorageType& actual);
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::FieldType& expected,
             const binary::FieldType& actual);
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::FieldTypeList& expected,
             const binary::FieldTypeList& actual);
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::FunctionType& expected,
             const binary::FunctionType& actual);
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::StructType& expected,
             const binary::StructType& actual);
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::ArrayType& expected,
             const binary::ArrayType& actual);
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::DefinedType& expected,
             const binary::DefinedType& actual);
 
-bool IsMatch(Context&,
+bool IsMatch(ValidCtx&,
              const binary::HeapType& expected,
              const binary::HeapType& actual);
-bool IsMatch(Context&,
+bool IsMatch(ValidCtx&,
              const binary::RefType& expected,
              const binary::RefType& actual);
-bool IsMatch(Context&,
+bool IsMatch(ValidCtx&,
              const binary::ReferenceType& expected,
              const binary::ReferenceType& actual);
-bool IsMatch(Context&, const binary::Rtt& expected, const binary::Rtt& actual);
-bool IsMatch(Context&,
+bool IsMatch(ValidCtx&, const binary::Rtt& expected, const binary::Rtt& actual);
+bool IsMatch(ValidCtx&,
              const binary::ValueType& expected,
              const binary::ValueType& actual);
-bool IsMatch(Context&,
+bool IsMatch(ValidCtx&,
              const binary::ValueTypeList& expected,
              const binary::ValueTypeList& actual);
-bool IsMatch(Context&, const StackType& expected, const StackType& actual);
-bool IsMatch(Context&, StackTypeSpan expected, StackTypeSpan actual);
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx&, const StackType& expected, const StackType& actual);
+bool IsMatch(ValidCtx&, StackTypeSpan expected, StackTypeSpan actual);
+bool IsMatch(ValidCtx& ctx,
              const binary::StorageType& expected,
              const binary::StorageType& actual);
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::FieldType& expected,
              const binary::FieldType& actual);
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::FieldTypeList& expected,
              const binary::FieldTypeList& actual);
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::FunctionType& expected,
              const binary::FunctionType& actual);
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::StructType& expected,
              const binary::StructType& actual);
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::ArrayType& expected,
              const binary::ArrayType& actual);
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::DefinedType& expected,
              const binary::DefinedType& actual);
 

--- a/include/wasp/valid/valid_ctx.h
+++ b/include/wasp/valid/valid_ctx.h
@@ -76,10 +76,10 @@ class TypeRelationSet {
   std::map<std::pair<Index, Index>, bool> assume_;
 };
 
-struct Context {
-  Context(Errors&);
-  Context(const Features&, Errors&);
-  Context(const Context&, Errors&);
+struct ValidCtx {
+  ValidCtx(Errors&);
+  ValidCtx(const Features&, Errors&);
+  ValidCtx(const ValidCtx&, Errors&);
 
   void Reset();
 

--- a/include/wasp/valid/validate.h
+++ b/include/wasp/valid/validate.h
@@ -27,74 +27,76 @@ enum class RequireDefaultable {
   Yes,
 };
 
-struct Context;
+struct ValidCtx;
 
-bool BeginTypeSection(Context&, Index type_count);
-bool BeginCode(Context&, Location loc);
+bool BeginTypeSection(ValidCtx&, Index type_count);
+bool BeginCode(ValidCtx&, Location loc);
 
-bool CheckDefaultable(Context&,
+bool CheckDefaultable(ValidCtx&,
                       const At<binary::ReferenceType>&,
                       string_view desc);
-bool CheckDefaultable(Context&, const At<binary::ValueType>&, string_view desc);
-bool CheckDefaultable(Context&,
+bool CheckDefaultable(ValidCtx&,
+                      const At<binary::ValueType>&,
+                      string_view desc);
+bool CheckDefaultable(ValidCtx&,
                       const At<binary::StorageType>&,
                       string_view desc);
 
-bool Validate(Context&, const At<binary::ArrayType>&);
-bool Validate(Context&, const At<binary::BlockType>&);
-bool Validate(Context&, const At<binary::DataSegment>&);
-bool Validate(Context&,
+bool Validate(ValidCtx&, const At<binary::ArrayType>&);
+bool Validate(ValidCtx&, const At<binary::BlockType>&);
+bool Validate(ValidCtx&, const At<binary::DataSegment>&);
+bool Validate(ValidCtx&,
               const At<binary::ConstantExpression>&,
               binary::ValueType expected_type,
               Index max_global_index);
-bool Validate(Context&, const At<binary::DataCount>&);
-bool Validate(Context&, const At<binary::DataSegment>&);
-bool Validate(Context&, const At<binary::DefinedType>&);
-bool Validate(Context&,
+bool Validate(ValidCtx&, const At<binary::DataCount>&);
+bool Validate(ValidCtx&, const At<binary::DataSegment>&);
+bool Validate(ValidCtx&, const At<binary::DefinedType>&);
+bool Validate(ValidCtx&,
               const At<binary::ElementExpression>&,
               binary::ReferenceType);
-bool Validate(Context&, const At<binary::ElementSegment>&);
-bool Validate(Context&, const At<binary::Export>&);
-bool Validate(Context&, const At<binary::Event>&);
-bool Validate(Context&, const At<binary::EventType>&);
-bool Validate(Context&, const At<binary::FieldType>&);
-bool Validate(Context&, const binary::FieldTypeList&);
-bool Validate(Context&, const At<binary::Function>&);
-bool Validate(Context&, const At<binary::FunctionType>&);
-bool Validate(Context&, const At<binary::Global>&);
-bool Validate(Context&, const At<binary::GlobalType>&);
-bool Validate(Context&, const At<binary::HeapType>&);
-bool Validate(Context&, const At<binary::Import>&);
-bool ValidateIndex(Context&,
+bool Validate(ValidCtx&, const At<binary::ElementSegment>&);
+bool Validate(ValidCtx&, const At<binary::Export>&);
+bool Validate(ValidCtx&, const At<binary::Event>&);
+bool Validate(ValidCtx&, const At<binary::EventType>&);
+bool Validate(ValidCtx&, const At<binary::FieldType>&);
+bool Validate(ValidCtx&, const binary::FieldTypeList&);
+bool Validate(ValidCtx&, const At<binary::Function>&);
+bool Validate(ValidCtx&, const At<binary::FunctionType>&);
+bool Validate(ValidCtx&, const At<binary::Global>&);
+bool Validate(ValidCtx&, const At<binary::GlobalType>&);
+bool Validate(ValidCtx&, const At<binary::HeapType>&);
+bool Validate(ValidCtx&, const At<binary::Import>&);
+bool ValidateIndex(ValidCtx&,
                    const At<Index>& index,
                    Index max,
                    string_view desc);
-bool Validate(Context&, const At<binary::Instruction>&);
-bool Validate(Context&, const At<Limits>&, Index max);
-bool Validate(Context&, const At<binary::Locals>&, RequireDefaultable);
-bool Validate(Context&, const At<binary::LocalsList>&, RequireDefaultable);
-bool Validate(Context&, const At<binary::Memory>&);
-bool Validate(Context&, const At<MemoryType>&);
-bool Validate(Context&, const At<binary::ReferenceType>&);
-bool Validate(Context&, const At<binary::RefType>&);
-bool Validate(Context&,
+bool Validate(ValidCtx&, const At<binary::Instruction>&);
+bool Validate(ValidCtx&, const At<Limits>&, Index max);
+bool Validate(ValidCtx&, const At<binary::Locals>&, RequireDefaultable);
+bool Validate(ValidCtx&, const At<binary::LocalsList>&, RequireDefaultable);
+bool Validate(ValidCtx&, const At<binary::Memory>&);
+bool Validate(ValidCtx&, const At<MemoryType>&);
+bool Validate(ValidCtx&, const At<binary::ReferenceType>&);
+bool Validate(ValidCtx&, const At<binary::RefType>&);
+bool Validate(ValidCtx&,
               binary::ReferenceType expected,
               const At<binary::ReferenceType>& actual);
-bool Validate(Context&, const At<binary::Rtt>&);
-bool Validate(Context&, const At<binary::Start>& value);
-bool Validate(Context&, const At<binary::StorageType>& value);
-bool Validate(Context&, const At<binary::StructType>& value);
-bool Validate(Context&, const At<binary::Table>&);
-bool Validate(Context&, const At<binary::TableType>&);
-bool Validate(Context&, const At<binary::ValueType>&);
-bool Validate(Context&,
+bool Validate(ValidCtx&, const At<binary::Rtt>&);
+bool Validate(ValidCtx&, const At<binary::Start>& value);
+bool Validate(ValidCtx&, const At<binary::StorageType>& value);
+bool Validate(ValidCtx&, const At<binary::StructType>& value);
+bool Validate(ValidCtx&, const At<binary::Table>&);
+bool Validate(ValidCtx&, const At<binary::TableType>&);
+bool Validate(ValidCtx&, const At<binary::ValueType>&);
+bool Validate(ValidCtx&,
               binary::ValueType expected,
               const At<binary::ValueType>& actual);
-bool Validate(Context&, const binary::ValueTypeList&);
-bool Validate(Context&, const At<binary::UnpackedCode>&);
-bool Validate(Context&, const At<binary::UnpackedExpression>&);
+bool Validate(ValidCtx&, const binary::ValueTypeList&);
+bool Validate(ValidCtx&, const At<binary::UnpackedCode>&);
+bool Validate(ValidCtx&, const At<binary::UnpackedExpression>&);
 
-bool Validate(Context&, const binary::Module&);
+bool Validate(ValidCtx&, const binary::Module&);
 
 }  // namespace wasp::valid
 

--- a/include/wasp/valid/validate_visitor.h
+++ b/include/wasp/valid/validate_visitor.h
@@ -18,7 +18,7 @@
 #define WASP_VALID_VALIDATE_VISITOR_H_
 
 #include "wasp/binary/visitor.h"
-#include "wasp/valid/context.h"
+#include "wasp/valid/valid_ctx.h"
 #include "wasp/valid/validate.h"
 
 namespace wasp {
@@ -49,7 +49,7 @@ struct ValidateVisitor : binary::visit::Visitor {
 
   auto FailUnless(bool) -> Result;
 
-  valid::Context context;
+  ValidCtx ctx;
   Features features;
   Errors& errors;
 };

--- a/src/binary/CMakeLists.txt
+++ b/src/binary/CMakeLists.txt
@@ -42,10 +42,10 @@ add_library(libwasp_binary
   ../../include/wasp/binary/name_section/sections.h
   ../../include/wasp/binary/name_section/types.h
   ../../include/wasp/binary/name_section/write.h
-  ../../include/wasp/binary/read/context.h
   ../../include/wasp/binary/read.h
   ../../include/wasp/binary/read/location_guard.h
   ../../include/wasp/binary/read/macros.h
+  ../../include/wasp/binary/read/read_ctx.h
   ../../include/wasp/binary/read/read_var_int.h
   ../../include/wasp/binary/read/read_vector.h
   ../../include/wasp/binary/sections.h
@@ -54,7 +54,6 @@ add_library(libwasp_binary
   ../../include/wasp/binary/visitor.h
   ../../include/wasp/binary/write.h
 
-  context.cc
   encoding.cc
   formatters.cc
   lazy_expression.cc
@@ -71,6 +70,7 @@ add_library(libwasp_binary
   name_section/sections.cc
   name_section/types.cc
   read.cc
+  read_ctx.cc
   read_module.cc
   sections.cc
   types.cc

--- a/src/binary/lazy_expression.cc
+++ b/src/binary/lazy_expression.cc
@@ -15,17 +15,17 @@
 //
 
 #include "wasp/binary/lazy_expression.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 
 namespace wasp::binary {
 
-LazyExpression ReadExpression(SpanU8 data, Context& context) {
-  context.seen_final_end = false;
-  return LazyExpression{data, context};
+LazyExpression ReadExpression(SpanU8 data, ReadCtx& ctx) {
+  ctx.seen_final_end = false;
+  return LazyExpression{data, ctx};
 }
 
-LazyExpression ReadExpression(Expression expr, Context& context) {
-  return ReadExpression(expr.data, context);
+LazyExpression ReadExpression(Expression expr, ReadCtx& ctx) {
+  return ReadExpression(expr.data, ctx);
 }
 
 }  // namespace wasp::binary

--- a/src/binary/lazy_module.cc
+++ b/src/binary/lazy_module.cc
@@ -31,10 +31,10 @@ constexpr SpanU8 kVersionSpan{encoding::Version};
 
 LazyModule::LazyModule(SpanU8 data, const Features& features, Errors& errors)
     : data{data},
-      context{features, errors},
-      magic{ReadBytesExpected(&data, kMagicSpan, context, "magic")},
-      version{ReadBytesExpected(&data, kVersionSpan, context, "version")},
-      sections{data, context} {}
+      ctx{features, errors},
+      magic{ReadBytesExpected(&data, kMagicSpan, ctx, "magic")},
+      version{ReadBytesExpected(&data, kVersionSpan, ctx, "version")},
+      sections{data, ctx} {}
 
 LazyModule ReadLazyModule(SpanU8 data,
                           const Features& features,

--- a/src/binary/linking_section/read.cc
+++ b/src/binary/linking_section/read.cc
@@ -21,84 +21,82 @@
 #include "wasp/base/macros.h"
 #include "wasp/binary/linking_section/encoding.h"
 #include "wasp/binary/read.h"
-#include "wasp/binary/read/context.h"
 #include "wasp/binary/read/location_guard.h"
 #include "wasp/binary/read/macros.h"
+#include "wasp/binary/read/read_ctx.h"
 #include "wasp/binary/read/read_vector.h"
 
 namespace wasp::binary {
 
-OptAt<Comdat> Read(SpanU8* data, Context& context, Tag<Comdat>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "comdat"};
+OptAt<Comdat> Read(SpanU8* data, ReadCtx& ctx, Tag<Comdat>) {
+  ErrorsContextGuard error_guard{ctx.errors, *data, "comdat"};
   LocationGuard guard{data};
-  WASP_TRY_READ(name, ReadString(data, context, "name"));
-  WASP_TRY_READ(flags, Read<u32>(data, context));
-  WASP_TRY_READ(symbols, ReadVector<ComdatSymbol>(data, context,
-                                                  "comdat symbols vector"));
+  WASP_TRY_READ(name, ReadString(data, ctx, "name"));
+  WASP_TRY_READ(flags, Read<u32>(data, ctx));
+  WASP_TRY_READ(symbols,
+                ReadVector<ComdatSymbol>(data, ctx, "comdat symbols vector"));
   return At{guard.range(data), Comdat{name, flags, std::move(symbols)}};
 }
 
-OptAt<ComdatSymbol> Read(SpanU8* data, Context& context, Tag<ComdatSymbol>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "comdat symbol"};
+OptAt<ComdatSymbol> Read(SpanU8* data, ReadCtx& ctx, Tag<ComdatSymbol>) {
+  ErrorsContextGuard error_guard{ctx.errors, *data, "comdat symbol"};
   LocationGuard guard{data};
-  WASP_TRY_READ(kind, Read<ComdatSymbolKind>(data, context));
-  WASP_TRY_READ(index, ReadIndex(data, context, "index"));
+  WASP_TRY_READ(kind, Read<ComdatSymbolKind>(data, ctx));
+  WASP_TRY_READ(index, ReadIndex(data, ctx, "index"));
   return At{guard.range(data), ComdatSymbol{kind, index}};
 }
 
 OptAt<ComdatSymbolKind> Read(SpanU8* data,
-                             Context& context,
+                             ReadCtx& ctx,
                              Tag<ComdatSymbolKind>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "comdat symbol kind"};
+  ErrorsContextGuard error_guard{ctx.errors, *data, "comdat symbol kind"};
   LocationGuard guard{data};
-  WASP_TRY_READ(val, Read<u8>(data, context));
+  WASP_TRY_READ(val, Read<u8>(data, ctx));
   WASP_TRY_DECODE(decoded, val, ComdatSymbolKind, "comdat symbol kind");
   return decoded;
 }
 
-OptAt<InitFunction> Read(SpanU8* data, Context& context, Tag<InitFunction>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "init function"};
+OptAt<InitFunction> Read(SpanU8* data, ReadCtx& ctx, Tag<InitFunction>) {
+  ErrorsContextGuard error_guard{ctx.errors, *data, "init function"};
   LocationGuard guard{data};
-  WASP_TRY_READ(priority, Read<u32>(data, context));
-  WASP_TRY_READ(index, ReadIndex(data, context, "function index"));
+  WASP_TRY_READ(priority, Read<u32>(data, ctx));
+  WASP_TRY_READ(index, ReadIndex(data, ctx, "function index"));
   return At{guard.range(data), InitFunction{priority, index}};
 }
 
 OptAt<LinkingSubsection> Read(SpanU8* data,
-                              Context& context,
+                              ReadCtx& ctx,
                               Tag<LinkingSubsection>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "linking subsection"};
+  ErrorsContextGuard error_guard{ctx.errors, *data, "linking subsection"};
   LocationGuard guard{data};
-  WASP_TRY_READ(id, Read<LinkingSubsectionId>(data, context));
-  WASP_TRY_READ(length, ReadLength(data, context));
-  auto bytes = *ReadBytes(data, length, context);
+  WASP_TRY_READ(id, Read<LinkingSubsectionId>(data, ctx));
+  WASP_TRY_READ(length, ReadLength(data, ctx));
+  auto bytes = *ReadBytes(data, length, ctx);
   return At{guard.range(data), LinkingSubsection{id, bytes}};
 }
 
 OptAt<LinkingSubsectionId> Read(SpanU8* data,
-                                Context& context,
+                                ReadCtx& ctx,
                                 Tag<LinkingSubsectionId>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "linking subsection id"};
-  WASP_TRY_READ(val, Read<u8>(data, context));
+  ErrorsContextGuard error_guard{ctx.errors, *data, "linking subsection id"};
+  WASP_TRY_READ(val, Read<u8>(data, ctx));
   WASP_TRY_DECODE(decoded, val, LinkingSubsectionId, "linking subsection id");
   return decoded;
 }
 
-OptAt<RelocationEntry> Read(SpanU8* data,
-                            Context& context,
-                            Tag<RelocationEntry>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "relocation entry"};
+OptAt<RelocationEntry> Read(SpanU8* data, ReadCtx& ctx, Tag<RelocationEntry>) {
+  ErrorsContextGuard error_guard{ctx.errors, *data, "relocation entry"};
   LocationGuard guard{data};
-  WASP_TRY_READ(type, Read<RelocationType>(data, context));
-  WASP_TRY_READ(offset, Read<u32>(data, context));
-  WASP_TRY_READ(index, ReadIndex(data, context, "index"));
+  WASP_TRY_READ(type, Read<RelocationType>(data, ctx));
+  WASP_TRY_READ(offset, Read<u32>(data, ctx));
+  WASP_TRY_READ(index, ReadIndex(data, ctx, "index"));
   switch (type) {
     case RelocationType::MemoryAddressLEB:
     case RelocationType::MemoryAddressSLEB:
     case RelocationType::MemoryAddressI32:
     case RelocationType::FunctionOffsetI32:
     case RelocationType::SectionOffsetI32: {
-      WASP_TRY_READ(addend, Read<s32>(data, context));
+      WASP_TRY_READ(addend, Read<s32>(data, ctx));
       return At{guard.range(data),
                 RelocationEntry{type, offset, index, addend}};
     }
@@ -109,39 +107,37 @@ OptAt<RelocationEntry> Read(SpanU8* data,
   }
 }
 
-OptAt<RelocationType> Read(SpanU8* data,
-                           Context& context,
-                           Tag<RelocationType>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "relocation type"};
-  WASP_TRY_READ(val, Read<u8>(data, context));
+OptAt<RelocationType> Read(SpanU8* data, ReadCtx& ctx, Tag<RelocationType>) {
+  ErrorsContextGuard error_guard{ctx.errors, *data, "relocation type"};
+  WASP_TRY_READ(val, Read<u8>(data, ctx));
   WASP_TRY_DECODE(decoded, val, RelocationType, "relocation type");
   return decoded;
 }
 
-OptAt<SegmentInfo> Read(SpanU8* data, Context& context, Tag<SegmentInfo>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "segment info"};
+OptAt<SegmentInfo> Read(SpanU8* data, ReadCtx& ctx, Tag<SegmentInfo>) {
+  ErrorsContextGuard error_guard{ctx.errors, *data, "segment info"};
   LocationGuard guard{data};
-  WASP_TRY_READ(name, ReadString(data, context, "name"));
-  WASP_TRY_READ(align_log2, Read<u32>(data, context));
-  WASP_TRY_READ(flags, Read<u32>(data, context));
+  WASP_TRY_READ(name, ReadString(data, ctx, "name"));
+  WASP_TRY_READ(align_log2, Read<u32>(data, ctx));
+  WASP_TRY_READ(flags, Read<u32>(data, ctx));
   return At{guard.range(data), SegmentInfo{name, align_log2, flags}};
 }
 
-OptAt<SymbolInfo> Read(SpanU8* data, Context& context, Tag<SymbolInfo>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "symbol info"};
+OptAt<SymbolInfo> Read(SpanU8* data, ReadCtx& ctx, Tag<SymbolInfo>) {
+  ErrorsContextGuard error_guard{ctx.errors, *data, "symbol info"};
   LocationGuard guard{data};
-  WASP_TRY_READ(kind, Read<SymbolInfoKind>(data, context));
-  WASP_TRY_READ(encoded_flags, Read<u32>(data, context));
+  WASP_TRY_READ(kind, Read<SymbolInfoKind>(data, ctx));
+  WASP_TRY_READ(encoded_flags, Read<u32>(data, ctx));
   WASP_TRY_DECODE(flags, encoded_flags, SymbolInfoFlags, "symbol info flags");
   switch (kind) {
     case SymbolInfoKind::Function:
     case SymbolInfoKind::Global:
     case SymbolInfoKind::Event: {
-      WASP_TRY_READ(index, ReadIndex(data, context, "index"));
+      WASP_TRY_READ(index, ReadIndex(data, ctx, "index"));
       optional<At<string_view>> name;
       if (flags->undefined == SymbolInfo::Flags::Undefined::No ||
           flags->explicit_name == SymbolInfo::Flags::ExplicitName::Yes) {
-        WASP_TRY_READ(name_, ReadString(data, context, "name"));
+        WASP_TRY_READ(name_, ReadString(data, ctx, "name"));
         name = name_;
       }
       return At{guard.range(data),
@@ -149,12 +145,12 @@ OptAt<SymbolInfo> Read(SpanU8* data, Context& context, Tag<SymbolInfo>) {
     }
 
     case SymbolInfoKind::Data: {
-      WASP_TRY_READ(name, ReadString(data, context, "name"));
+      WASP_TRY_READ(name, ReadString(data, ctx, "name"));
       optional<SymbolInfo::Data::Defined> defined;
       if (flags->undefined == SymbolInfo::Flags::Undefined::No) {
-        WASP_TRY_READ(index, ReadIndex(data, context, "segment index"));
-        WASP_TRY_READ(offset, Read<u32>(data, context));
-        WASP_TRY_READ(size, Read<u32>(data, context));
+        WASP_TRY_READ(index, ReadIndex(data, ctx, "segment index"));
+        WASP_TRY_READ(offset, Read<u32>(data, ctx));
+        WASP_TRY_READ(size, Read<u32>(data, ctx));
         defined = SymbolInfo::Data::Defined{index, offset, size};
       }
       return At{guard.range(data),
@@ -162,18 +158,16 @@ OptAt<SymbolInfo> Read(SpanU8* data, Context& context, Tag<SymbolInfo>) {
     }
 
     case SymbolInfoKind::Section:
-      WASP_TRY_READ(section, Read<u32>(data, context));
+      WASP_TRY_READ(section, Read<u32>(data, ctx));
       return At{guard.range(data),
                 SymbolInfo{flags, SymbolInfo::Section{section}}};
   }
   WASP_UNREACHABLE();
 }
 
-OptAt<SymbolInfoKind> Read(SpanU8* data,
-                           Context& context,
-                           Tag<SymbolInfoKind>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "symbol info kind"};
-  WASP_TRY_READ(val, Read<u8>(data, context));
+OptAt<SymbolInfoKind> Read(SpanU8* data, ReadCtx& ctx, Tag<SymbolInfoKind>) {
+  ErrorsContextGuard error_guard{ctx.errors, *data, "symbol info kind"};
+  WASP_TRY_READ(val, Read<u8>(data, ctx));
   WASP_TRY_DECODE(decoded, val, SymbolInfoKind, "symbol info kind");
   return decoded;
 }

--- a/src/binary/linking_section/sections.cc
+++ b/src/binary/linking_section/sections.cc
@@ -22,79 +22,77 @@
 
 namespace wasp::binary {
 
-LinkingSection::LinkingSection(SpanU8 data, Context& context)
+LinkingSection::LinkingSection(SpanU8 data, ReadCtx& ctx)
     : data{data},
-      version{Read<u32>(&data, context)},
-      subsections{data, context} {
+      version{Read<u32>(&data, ctx)},
+      subsections{data, ctx} {
   constexpr u32 kVersion = 2;
   if (version && version != kVersion) {
-    context.errors.OnError(data, concat("Expected linking section version: ",
-                                        kVersion, ", got ", *version));
+    ctx.errors.OnError(data, concat("Expected linking section version: ",
+                                    kVersion, ", got ", *version));
   }
 }
 
-auto ReadLinkingSection(SpanU8 data, Context& context) -> LinkingSection {
-  return LinkingSection{data, context};
+auto ReadLinkingSection(SpanU8 data, ReadCtx& ctx) -> LinkingSection {
+  return LinkingSection{data, ctx};
 }
 
-auto ReadLinkingSection(CustomSection sec, Context& context) -> LinkingSection {
-  return LinkingSection{sec.data, context};
+auto ReadLinkingSection(CustomSection sec, ReadCtx& ctx) -> LinkingSection {
+  return LinkingSection{sec.data, ctx};
 }
 
-RelocationSection::RelocationSection(SpanU8 data, Context& context)
+RelocationSection::RelocationSection(SpanU8 data, ReadCtx& ctx)
     : data{data},
-      section_index{Read<u32>(&data, context)},
-      count{ReadCount(&data, context)},
-      entries{data, count, "relocation section", context} {}
+      section_index{Read<u32>(&data, ctx)},
+      count{ReadCount(&data, ctx)},
+      entries{data, count, "relocation section", ctx} {}
 
-auto ReadRelocationSection(SpanU8 data, Context& context) -> RelocationSection {
-  return RelocationSection{data, context};
+auto ReadRelocationSection(SpanU8 data, ReadCtx& ctx) -> RelocationSection {
+  return RelocationSection{data, ctx};
 }
 
-auto ReadRelocationSection(CustomSection sec, Context& context)
+auto ReadRelocationSection(CustomSection sec, ReadCtx& ctx)
     -> RelocationSection {
-  return RelocationSection{sec.data, context};
+  return RelocationSection{sec.data, ctx};
 }
 
-auto ReadComdatSubsection(SpanU8 data, Context& context)
+auto ReadComdatSubsection(SpanU8 data, ReadCtx& ctx) -> LazyComdatSubsection {
+  return LazyComdatSubsection{data, "comdat subsection", ctx};
+}
+
+auto ReadComdatSubsection(LinkingSubsection sec, ReadCtx& ctx)
     -> LazyComdatSubsection {
-  return LazyComdatSubsection{data, "comdat subsection", context};
+  return ReadComdatSubsection(sec.data, ctx);
 }
 
-auto ReadComdatSubsection(LinkingSubsection sec, Context& context)
-    -> LazyComdatSubsection {
-  return ReadComdatSubsection(sec.data, context);
-}
-
-auto ReadInitFunctionsSubsection(SpanU8 data, Context& context)
+auto ReadInitFunctionsSubsection(SpanU8 data, ReadCtx& ctx)
     -> LazyInitFunctionsSubsection {
-  return LazyInitFunctionsSubsection{data, "init functions subsection",
-                                     context};
+  return LazyInitFunctionsSubsection{data, "init functions subsection", ctx};
 }
 
-auto ReadInitFunctionsSubsection(LinkingSubsection sec, Context& context)
+auto ReadInitFunctionsSubsection(LinkingSubsection sec, ReadCtx& ctx)
     -> LazyInitFunctionsSubsection {
-  return ReadInitFunctionsSubsection(sec.data, context);
+  return ReadInitFunctionsSubsection(sec.data, ctx);
 }
 
-auto ReadSegmentInfoSubsection(SpanU8 data, Context& context)
+auto ReadSegmentInfoSubsection(SpanU8 data, ReadCtx& ctx)
     -> LazySegmentInfoSubsection {
-  return LazySegmentInfoSubsection{data, "segment info subsection", context};
+  return LazySegmentInfoSubsection{data, "segment info subsection", ctx};
 }
 
-auto ReadSegmentInfoSubsection(LinkingSubsection sec, Context& context)
+auto ReadSegmentInfoSubsection(LinkingSubsection sec, ReadCtx& ctx)
     -> LazySegmentInfoSubsection {
-  return ReadSegmentInfoSubsection(sec.data, context);
+  return ReadSegmentInfoSubsection(sec.data, ctx);
 }
 
-auto ReadSymbolTableSubsection(SpanU8 data, Context& context)
+auto ReadSymbolTableSubsection(SpanU8 data, ReadCtx& ctx)
     -> LazySymbolTableSubsection {
-  return LazySymbolTableSubsection{data, "symbol table subsection", context};
+  return LazySymbolTableSubsection{data, "symbol table subsection", ctx};
 }
 
-auto ReadSymbolTableSubsection(LinkingSubsection sec, Context& context)
+auto ReadSymbolTableSubsection(LinkingSubsection sec, ReadCtx& ctx)
     -> LazySymbolTableSubsection {
-  return ReadSymbolTableSubsection(sec.data, context);
+  return ReadSymbolTableSubsection(sec.data, ctx);
 }
 
 }  // namespace wasp::binary

--- a/src/binary/name_section/read.cc
+++ b/src/binary/name_section/read.cc
@@ -20,48 +20,46 @@
 #include "wasp/base/formatters.h"
 #include "wasp/binary/name_section/encoding.h"
 #include "wasp/binary/read.h"
-#include "wasp/binary/read/context.h"
 #include "wasp/binary/read/location_guard.h"
 #include "wasp/binary/read/macros.h"
+#include "wasp/binary/read/read_ctx.h"
 #include "wasp/binary/read/read_vector.h"
 
 namespace wasp::binary {
 
 OptAt<IndirectNameAssoc> Read(SpanU8* data,
-                              Context& context,
+                              ReadCtx& ctx,
                               Tag<IndirectNameAssoc>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "indirect name assoc"};
+  ErrorsContextGuard error_guard{ctx.errors, *data, "indirect name assoc"};
   LocationGuard guard{data};
-  WASP_TRY_READ(index, ReadIndex(data, context, "index"));
-  WASP_TRY_READ(name_map, ReadVector<NameAssoc>(data, context, "name map"));
+  WASP_TRY_READ(index, ReadIndex(data, ctx, "index"));
+  WASP_TRY_READ(name_map, ReadVector<NameAssoc>(data, ctx, "name map"));
   return At{guard.range(data), IndirectNameAssoc{index, std::move(name_map)}};
 }
 
-OptAt<NameAssoc> Read(SpanU8* data, Context& context, Tag<NameAssoc>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "name assoc"};
+OptAt<NameAssoc> Read(SpanU8* data, ReadCtx& ctx, Tag<NameAssoc>) {
+  ErrorsContextGuard error_guard{ctx.errors, *data, "name assoc"};
   LocationGuard guard{data};
-  WASP_TRY_READ(index, ReadIndex(data, context, "index"));
-  WASP_TRY_READ(name, ReadString(data, context, "name"));
+  WASP_TRY_READ(index, ReadIndex(data, ctx, "index"));
+  WASP_TRY_READ(name, ReadString(data, ctx, "name"));
   return At{guard.range(data), NameAssoc{index, name}};
 }
 
-OptAt<NameSubsection> Read(SpanU8* data,
-                           Context& context,
-                           Tag<NameSubsection>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "name subsection"};
+OptAt<NameSubsection> Read(SpanU8* data, ReadCtx& ctx, Tag<NameSubsection>) {
+  ErrorsContextGuard error_guard{ctx.errors, *data, "name subsection"};
   LocationGuard guard{data};
-  WASP_TRY_READ(id, Read<NameSubsectionId>(data, context));
-  WASP_TRY_READ(length, ReadLength(data, context));
-  WASP_TRY_READ(bytes, ReadBytes(data, length, context));
+  WASP_TRY_READ(id, Read<NameSubsectionId>(data, ctx));
+  WASP_TRY_READ(length, ReadLength(data, ctx));
+  WASP_TRY_READ(bytes, ReadBytes(data, length, ctx));
   return At{guard.range(data), NameSubsection{id, *bytes}};
 }
 
 OptAt<NameSubsectionId> Read(SpanU8* data,
-                             Context& context,
+                             ReadCtx& ctx,
                              Tag<NameSubsectionId>) {
-  ErrorsContextGuard error_guard{context.errors, *data, "name subsection id"};
+  ErrorsContextGuard error_guard{ctx.errors, *data, "name subsection id"};
   LocationGuard guard{data};
-  WASP_TRY_READ(val, Read<u8>(data, context));
+  WASP_TRY_READ(val, Read<u8>(data, ctx));
   WASP_TRY_DECODE(decoded, val, NameSubsectionId, "name subsection id");
   return At{guard.range(data), decoded};
 }

--- a/src/binary/name_section/sections.cc
+++ b/src/binary/name_section/sections.cc
@@ -18,43 +18,42 @@
 
 namespace wasp::binary {
 
-auto ReadNameSection(SpanU8 data, Context& context) -> LazyNameSection {
-  return LazyNameSection{data, context};
+auto ReadNameSection(SpanU8 data, ReadCtx& ctx) -> LazyNameSection {
+  return LazyNameSection{data, ctx};
 }
 
-auto ReadNameSection(CustomSection sec, Context& context) -> LazyNameSection {
-  return LazyNameSection{sec.data, context};
+auto ReadNameSection(CustomSection sec, ReadCtx& ctx) -> LazyNameSection {
+  return LazyNameSection{sec.data, ctx};
 }
 
-auto ReadFunctionNamesSubsection(SpanU8 data, Context& context)
+auto ReadFunctionNamesSubsection(SpanU8 data, ReadCtx& ctx)
     -> LazyFunctionNamesSubsection {
-  return LazyFunctionNamesSubsection{data, "function names subsection",
-                                     context};
+  return LazyFunctionNamesSubsection{data, "function names subsection", ctx};
 }
 
-auto ReadFunctionNamesSubsection(NameSubsection sec, Context& context)
+auto ReadFunctionNamesSubsection(NameSubsection sec, ReadCtx& ctx)
     -> LazyFunctionNamesSubsection {
-  return ReadFunctionNamesSubsection(sec.data, context);
+  return ReadFunctionNamesSubsection(sec.data, ctx);
 }
 
-auto ReadLocalNamesSubsection(SpanU8 data, Context& context)
+auto ReadLocalNamesSubsection(SpanU8 data, ReadCtx& ctx)
     -> LazyLocalNamesSubsection {
-  return LazyLocalNamesSubsection{data, "local names subsection", context};
+  return LazyLocalNamesSubsection{data, "local names subsection", ctx};
 }
 
-auto ReadLocalNamesSubsection(NameSubsection sec, Context& context)
+auto ReadLocalNamesSubsection(NameSubsection sec, ReadCtx& ctx)
     -> LazyLocalNamesSubsection {
-  return ReadLocalNamesSubsection(sec.data, context);
+  return ReadLocalNamesSubsection(sec.data, ctx);
 }
 
-auto ReadModuleNameSubsection(SpanU8 data, Context& context)
+auto ReadModuleNameSubsection(SpanU8 data, ReadCtx& ctx)
     -> ModuleNameSubsection {
-  return ReadString(&data, context, "module name");
+  return ReadString(&data, ctx, "module name");
 }
 
-auto ReadModuleNameSubsection(NameSubsection sec, Context& context)
+auto ReadModuleNameSubsection(NameSubsection sec, ReadCtx& ctx)
     -> ModuleNameSubsection {
-  return ReadModuleNameSubsection(sec.data, context);
+  return ReadModuleNameSubsection(sec.data, ctx);
 }
 
 }  // namespace wasp::binary

--- a/src/binary/read_ctx.cc
+++ b/src/binary/read_ctx.cc
@@ -14,18 +14,21 @@
 // limitations under the License.
 //
 
-#include "wasp/text/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 
-namespace wasp::text {
+namespace wasp::binary {
 
-Context::Context(Errors& errors) : errors{errors} {}
+ReadCtx::ReadCtx(Errors& errors) : errors(errors) {}
 
-Context::Context(const Features& features, Errors& errors)
-    : features{features}, errors{errors} {}
+ReadCtx::ReadCtx(const Features& features, Errors& errors)
+    : features(features), errors(errors) {}
 
-void Context::BeginModule() {
-  seen_non_import = false;
-  seen_start = false;
+void ReadCtx::Reset() {
+  last_section_id.reset();
+  defined_function_count = 0;
+  declared_data_count.reset();
+  code_count = 0;
+  data_count = 0;
 }
 
-}  // namespace wasp::text
+}  // namespace wasp::binary

--- a/src/binary/read_module.cc
+++ b/src/binary/read_module.cc
@@ -102,17 +102,16 @@ struct EagerModuleVisitor : visit::Visitor {
   Module& module;
 };
 
-auto ReadModule(SpanU8 data, Context& context) -> optional<Module> {
-  ErrorsContextGuard error_guard{context.errors, data, "module"};
-  LazyModule lazy_module{data, context.features, context.errors};
+auto ReadModule(SpanU8 data, ReadCtx& ctx) -> optional<Module> {
+  ErrorsContextGuard error_guard{ctx.errors, data, "module"};
+  LazyModule lazy_module{data, ctx.features, ctx.errors};
   if (!(lazy_module.magic.has_value() && lazy_module.version.has_value())) {
     return nullopt;
   }
 
   Module module;
   EagerModuleVisitor visitor{module};
-  if (Visit(lazy_module, visitor) == Result::Fail ||
-      context.errors.HasError()) {
+  if (Visit(lazy_module, visitor) == Result::Fail || ctx.errors.HasError()) {
     return nullopt;
   }
   return module;

--- a/src/binary/sections.cc
+++ b/src/binary/sections.cc
@@ -21,108 +21,102 @@
 
 namespace wasp::binary {
 
-auto ReadCodeSection(SpanU8 data, Context& context) -> LazyCodeSection {
-  return LazyCodeSection{data, "code section", context};
+auto ReadCodeSection(SpanU8 data, ReadCtx& ctx) -> LazyCodeSection {
+  return LazyCodeSection{data, "code section", ctx};
 }
 
-auto ReadCodeSection(KnownSection sec, Context& context) -> LazyCodeSection {
-  return ReadCodeSection(sec.data, context);
+auto ReadCodeSection(KnownSection sec, ReadCtx& ctx) -> LazyCodeSection {
+  return ReadCodeSection(sec.data, ctx);
 }
 
-auto ReadDataSection(SpanU8 data, Context& context) -> LazyDataSection {
-  return LazyDataSection{data, "data section", context};
+auto ReadDataSection(SpanU8 data, ReadCtx& ctx) -> LazyDataSection {
+  return LazyDataSection{data, "data section", ctx};
 }
 
-auto ReadDataSection(KnownSection sec, Context& context) -> LazyDataSection {
-  return ReadDataSection(sec.data, context);
+auto ReadDataSection(KnownSection sec, ReadCtx& ctx) -> LazyDataSection {
+  return ReadDataSection(sec.data, ctx);
 }
 
-auto ReadDataCountSection(SpanU8 data, Context& context) -> DataCountSection {
+auto ReadDataCountSection(SpanU8 data, ReadCtx& ctx) -> DataCountSection {
   SpanU8 copy = data;
-  return Read<DataCount>(&copy, context);
+  return Read<DataCount>(&copy, ctx);
 }
 
-auto ReadDataCountSection(KnownSection sec, Context& context)
-    -> DataCountSection {
-  return ReadDataCountSection(sec.data, context);
+auto ReadDataCountSection(KnownSection sec, ReadCtx& ctx) -> DataCountSection {
+  return ReadDataCountSection(sec.data, ctx);
 }
 
-auto ReadElementSection(SpanU8 data, Context& context) -> LazyElementSection {
-  return LazyElementSection{data, "element section", context};
+auto ReadElementSection(SpanU8 data, ReadCtx& ctx) -> LazyElementSection {
+  return LazyElementSection{data, "element section", ctx};
 }
 
-auto ReadElementSection(KnownSection sec, Context& context)
-    -> LazyElementSection {
-  return ReadElementSection(sec.data, context);
+auto ReadElementSection(KnownSection sec, ReadCtx& ctx) -> LazyElementSection {
+  return ReadElementSection(sec.data, ctx);
 }
 
-auto ReadEventSection(SpanU8 data, Context& context) -> LazyEventSection {
-  return LazyEventSection{data, "event section", context};
+auto ReadEventSection(SpanU8 data, ReadCtx& ctx) -> LazyEventSection {
+  return LazyEventSection{data, "event section", ctx};
 }
 
-auto ReadEventSection(KnownSection sec, Context& context) -> LazyEventSection {
-  return ReadEventSection(sec.data, context);
+auto ReadEventSection(KnownSection sec, ReadCtx& ctx) -> LazyEventSection {
+  return ReadEventSection(sec.data, ctx);
 }
 
-auto ReadExportSection(SpanU8 data, Context& context) -> LazyExportSection {
-  return LazyExportSection{data, "export section", context};
+auto ReadExportSection(SpanU8 data, ReadCtx& ctx) -> LazyExportSection {
+  return LazyExportSection{data, "export section", ctx};
 }
 
-auto ReadExportSection(KnownSection sec, Context& context)
-    -> LazyExportSection {
-  return ReadExportSection(sec.data, context);
+auto ReadExportSection(KnownSection sec, ReadCtx& ctx) -> LazyExportSection {
+  return ReadExportSection(sec.data, ctx);
 }
 
-auto ReadFunctionSection(SpanU8 data, Context& context) -> LazyFunctionSection {
-  return LazyFunctionSection{data, "function section", context};
+auto ReadFunctionSection(SpanU8 data, ReadCtx& ctx) -> LazyFunctionSection {
+  return LazyFunctionSection{data, "function section", ctx};
 }
 
-auto ReadFunctionSection(KnownSection sec, Context& context)
+auto ReadFunctionSection(KnownSection sec, ReadCtx& ctx)
     -> LazyFunctionSection {
-  return ReadFunctionSection(sec.data, context);
+  return ReadFunctionSection(sec.data, ctx);
 }
 
-auto ReadGlobalSection(SpanU8 data, Context& context) -> LazyGlobalSection {
-  return LazyGlobalSection{data, "global section", context};
+auto ReadGlobalSection(SpanU8 data, ReadCtx& ctx) -> LazyGlobalSection {
+  return LazyGlobalSection{data, "global section", ctx};
 }
 
-auto ReadGlobalSection(KnownSection sec, Context& context)
-    -> LazyGlobalSection {
-  return ReadGlobalSection(sec.data, context);
+auto ReadGlobalSection(KnownSection sec, ReadCtx& ctx) -> LazyGlobalSection {
+  return ReadGlobalSection(sec.data, ctx);
 }
 
-auto ReadImportSection(SpanU8 data, Context& context) -> LazyImportSection {
-  return LazyImportSection{data, "import section", context};
+auto ReadImportSection(SpanU8 data, ReadCtx& ctx) -> LazyImportSection {
+  return LazyImportSection{data, "import section", ctx};
 }
 
-auto ReadImportSection(KnownSection sec, Context& context)
-    -> LazyImportSection {
-  return ReadImportSection(sec.data, context);
+auto ReadImportSection(KnownSection sec, ReadCtx& ctx) -> LazyImportSection {
+  return ReadImportSection(sec.data, ctx);
 }
 
-auto ReadMemorySection(SpanU8 data, Context& context) -> LazyMemorySection {
-  return LazyMemorySection{data, "memory section", context};
+auto ReadMemorySection(SpanU8 data, ReadCtx& ctx) -> LazyMemorySection {
+  return LazyMemorySection{data, "memory section", ctx};
 }
 
-auto ReadMemorySection(KnownSection sec, Context& context)
-    -> LazyMemorySection {
-  return ReadMemorySection(sec.data, context);
+auto ReadMemorySection(KnownSection sec, ReadCtx& ctx) -> LazyMemorySection {
+  return ReadMemorySection(sec.data, ctx);
 }
 
-auto ReadTableSection(SpanU8 data, Context& context) -> LazyTableSection {
-  return LazyTableSection{data, "table section", context};
+auto ReadTableSection(SpanU8 data, ReadCtx& ctx) -> LazyTableSection {
+  return LazyTableSection{data, "table section", ctx};
 }
 
-auto ReadTableSection(KnownSection sec, Context& context) -> LazyTableSection {
-  return ReadTableSection(sec.data, context);
+auto ReadTableSection(KnownSection sec, ReadCtx& ctx) -> LazyTableSection {
+  return ReadTableSection(sec.data, ctx);
 }
 
-auto ReadTypeSection(SpanU8 data, Context& context) -> LazyTypeSection {
-  return LazyTypeSection{data, "type section", context};
+auto ReadTypeSection(SpanU8 data, ReadCtx& ctx) -> LazyTypeSection {
+  return LazyTypeSection{data, "type section", ctx};
 }
 
-auto ReadTypeSection(KnownSection sec, Context& context) -> LazyTypeSection {
-  return ReadTypeSection(sec.data, context);
+auto ReadTypeSection(KnownSection sec, ReadCtx& ctx) -> LazyTypeSection {
+  return ReadTypeSection(sec.data, ctx);
 }
 
 }  // namespace wasp::binary

--- a/src/text/CMakeLists.txt
+++ b/src/text/CMakeLists.txt
@@ -21,30 +21,30 @@ add_library(libwasp_text
   ../../include/wasp/text/numeric.h
   ../../include/wasp/text/read.h
   ../../include/wasp/text/resolve.h
-  ../../include/wasp/text/resolve_context.h
+  ../../include/wasp/text/resolve_ctx.h
   ../../include/wasp/text/types.h
   ../../include/wasp/text/write.h
   ../../include/wasp/text/token_type.inc
-  ../../include/wasp/text/read/context.h
   ../../include/wasp/text/read/lex.h
   ../../include/wasp/text/read/location_guard.h
   ../../include/wasp/text/read/macros.h
   ../../include/wasp/text/read/name_map.h
+  ../../include/wasp/text/read/read_ctx.h
   ../../include/wasp/text/read/token-inl.h
   ../../include/wasp/text/read/token.h
   ../../include/wasp/text/read/tokenizer-inl.h
   ../../include/wasp/text/read/tokenizer.h
 
-  context.cc
   desugar.cc
   formatters.cc
   lex.cc
   name_map.cc
   numeric.cc
   read.cc
+  read_ctx.cc
   read_script.cc
   resolve.cc
-  resolve_context.cc
+  resolve_ctx.cc
   token.cc
   types.cc
 )

--- a/src/text/read.cc
+++ b/src/text/read.cc
@@ -27,30 +27,30 @@
 #include "wasp/base/utf8.h"
 #include "wasp/text/formatters.h"
 #include "wasp/text/numeric.h"
-#include "wasp/text/read/context.h"
 #include "wasp/text/read/location_guard.h"
 #include "wasp/text/read/macros.h"
+#include "wasp/text/read/read_ctx.h"
 
 namespace wasp::text {
 
-auto Expect(Tokenizer& tokenizer, Context& context, TokenType expected)
+auto Expect(Tokenizer& tokenizer, ReadCtx& ctx, TokenType expected)
     -> optional<Token> {
   auto actual_opt = tokenizer.Match(expected);
   if (!actual_opt) {
     auto token = tokenizer.Peek();
-    context.errors.OnError(token.loc,
-                           concat("Expected ", expected, ", got ", token.type));
+    ctx.errors.OnError(token.loc,
+                       concat("Expected ", expected, ", got ", token.type));
     return nullopt;
   }
   return actual_opt;
 }
 
-auto ExpectLpar(Tokenizer& tokenizer, Context& context, TokenType expected)
+auto ExpectLpar(Tokenizer& tokenizer, ReadCtx& ctx, TokenType expected)
     -> optional<Token> {
   auto actual_opt = tokenizer.MatchLpar(expected);
   if (!actual_opt) {
     auto token = tokenizer.Peek();
-    context.errors.OnError(
+    ctx.errors.OnError(
         token.loc, concat("Expected '(' ", expected, ", got ", token.type, " ",
                           tokenizer.Peek(1).type));
     return nullopt;
@@ -59,61 +59,58 @@ auto ExpectLpar(Tokenizer& tokenizer, Context& context, TokenType expected)
 }
 
 template <typename T>
-auto ReadNat(Tokenizer& tokenizer, Context& context) -> OptAt<T> {
+auto ReadNat(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<T> {
   auto token_opt = tokenizer.Match(TokenType::Nat);
   if (!token_opt) {
     auto token = tokenizer.Peek();
-    context.errors.OnError(
-        token.loc, concat("Expected a natural number, got ", token.type));
+    ctx.errors.OnError(token.loc,
+                       concat("Expected a natural number, got ", token.type));
     return nullopt;
   }
   auto nat_opt = StrToNat<T>(token_opt->literal_info(), token_opt->span_u8());
   if (!nat_opt) {
-    context.errors.OnError(
-        token_opt->loc,
-        concat("Invalid natural number, got ", token_opt->type));
+    ctx.errors.OnError(token_opt->loc,
+                       concat("Invalid natural number, got ", token_opt->type));
     return nullopt;
   }
   return At{token_opt->loc, *nat_opt};
 }
 
-auto ReadNat32(Tokenizer& tokenizer, Context& context) -> OptAt<u32> {
-  return ReadNat<u32>(tokenizer, context);
+auto ReadNat32(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<u32> {
+  return ReadNat<u32>(tokenizer, ctx);
 }
 
 template <typename T>
-auto ReadInt(Tokenizer& tokenizer, Context& context) -> OptAt<T> {
+auto ReadInt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<T> {
   auto token = tokenizer.Peek();
   if (!(token.type == TokenType::Nat || token.type == TokenType::Int)) {
-    context.errors.OnError(token.loc,
-                           concat("Expected an integer, got ", token.type));
+    ctx.errors.OnError(token.loc,
+                       concat("Expected an integer, got ", token.type));
     return nullopt;
   }
 
   tokenizer.Read();
   auto int_opt = StrToInt<T>(token.literal_info(), token.span_u8());
   if (!int_opt) {
-    context.errors.OnError(token.loc,
-                           concat("Invalid integer, got ", token.type));
+    ctx.errors.OnError(token.loc, concat("Invalid integer, got ", token.type));
     return nullopt;
   }
   return At{token.loc, *int_opt};
 }
 
 template <typename T>
-auto ReadFloat(Tokenizer& tokenizer, Context& context) -> OptAt<T> {
+auto ReadFloat(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<T> {
   auto token = tokenizer.Peek();
   if (!(token.type == TokenType::Nat || token.type == TokenType::Int ||
         token.type == TokenType::Float)) {
-    context.errors.OnError(token.loc,
-                           concat("Expected a float, got ", token.type));
+    ctx.errors.OnError(token.loc, concat("Expected a float, got ", token.type));
     return nullopt;
   }
 
   tokenizer.Read();
   auto float_opt = StrToFloat<T>(token.literal_info(), token.span_u8());
   if (!float_opt) {
-    context.errors.OnError(token.loc, concat("Invalid float, got ", token));
+    ctx.errors.OnError(token.loc, concat("Invalid float, got ", token));
     return nullopt;
   }
   return At{token.loc, *float_opt};
@@ -123,99 +120,98 @@ bool IsVar(Token token) {
   return token.type == TokenType::Id || token.type == TokenType::Nat;
 }
 
-auto ReadVar(Tokenizer& tokenizer, Context& context) -> OptAt<Var> {
+auto ReadVar(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Var> {
   auto token = tokenizer.Peek();
-  auto var_opt = ReadVarOpt(tokenizer, context);
+  auto var_opt = ReadVarOpt(tokenizer, ctx);
   if (!var_opt) {
-    context.errors.OnError(token.loc,
-                           concat("Expected a variable, got ", token.type));
+    ctx.errors.OnError(token.loc,
+                       concat("Expected a variable, got ", token.type));
     return nullopt;
   }
   return *var_opt;
 }
 
-auto ReadVarOpt(Tokenizer& tokenizer, Context& context) -> OptAt<Var> {
+auto ReadVarOpt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Var> {
   auto token = tokenizer.Peek();
   if (token.type == TokenType::Id) {
     tokenizer.Read();
     return At{token.loc, Var{token.as_string_view()}};
   } else if (token.type == TokenType::Nat) {
-    WASP_TRY_READ(nat, ReadNat32(tokenizer, context));
+    WASP_TRY_READ(nat, ReadNat32(tokenizer, ctx));
     return At{nat.loc(), Var{nat.value()}};
   } else {
     return nullopt;
   }
 }
 
-auto ReadVarList(Tokenizer& tokenizer, Context& context) -> optional<VarList> {
+auto ReadVarList(Tokenizer& tokenizer, ReadCtx& ctx) -> optional<VarList> {
   VarList result;
   OptAt<Var> var_opt;
-  while ((var_opt = ReadVarOpt(tokenizer, context))) {
+  while ((var_opt = ReadVarOpt(tokenizer, ctx))) {
     result.push_back(*var_opt);
   }
   return result;
 }
 
-auto ReadNonEmptyVarList(Tokenizer& tokenizer, Context& context)
+auto ReadNonEmptyVarList(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<VarList> {
   VarList result;
-  WASP_TRY_READ(var, ReadVar(tokenizer, context));
+  WASP_TRY_READ(var, ReadVar(tokenizer, ctx));
   result.push_back(var);
 
-  WASP_TRY_READ(var_list, ReadVarList(tokenizer, context));
+  WASP_TRY_READ(var_list, ReadVarList(tokenizer, ctx));
   result.insert(result.end(), std::make_move_iterator(var_list.begin()),
                 std::make_move_iterator(var_list.end()));
   return result;
 }
 
-auto ReadVarUseOpt(Tokenizer& tokenizer, Context& context, TokenType token_type)
+auto ReadVarUseOpt(Tokenizer& tokenizer, ReadCtx& ctx, TokenType token_type)
     -> OptAt<Var> {
   LocationGuard guard{tokenizer};
   if (!tokenizer.MatchLpar(token_type)) {
     return nullopt;
   }
-  WASP_TRY_READ(var, ReadVar(tokenizer, context));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY_READ(var, ReadVar(tokenizer, ctx));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), var.value()};
 }
 
-auto ReadTypeUseOpt(Tokenizer& tokenizer, Context& context) -> OptAt<Var> {
-  return ReadVarUseOpt(tokenizer, context, TokenType::Type);
+auto ReadTypeUseOpt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Var> {
+  return ReadVarUseOpt(tokenizer, ctx, TokenType::Type);
 }
 
-auto ReadFunctionTypeUse(Tokenizer& tokenizer, Context& context)
+auto ReadFunctionTypeUse(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<FunctionTypeUse> {
-  auto type_use = ReadTypeUseOpt(tokenizer, context);
-  WASP_TRY_READ(type, ReadFunctionType(tokenizer, context));
+  auto type_use = ReadTypeUseOpt(tokenizer, ctx);
+  WASP_TRY_READ(type, ReadFunctionType(tokenizer, ctx));
   return FunctionTypeUse{type_use, type};
 }
 
-auto ReadText(Tokenizer& tokenizer, Context& context) -> OptAt<Text> {
+auto ReadText(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Text> {
   auto token_opt = tokenizer.Match(TokenType::Text);
   if (!token_opt) {
     auto token = tokenizer.Peek();
-    context.errors.OnError(token.loc,
-                           concat("Expected quoted text, got ", token.type));
+    ctx.errors.OnError(token.loc,
+                       concat("Expected quoted text, got ", token.type));
     return nullopt;
   }
   return At{token_opt->loc, token_opt->text()};
 }
 
-auto ReadUtf8Text(Tokenizer& tokenizer, Context& context) -> OptAt<Text> {
-  WASP_TRY_READ(text, ReadText(tokenizer, context));
+auto ReadUtf8Text(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Text> {
+  WASP_TRY_READ(text, ReadText(tokenizer, ctx));
   // TODO: The lexer could validate utf-8 while reading characters.
   if (!IsValidUtf8(text->ToString())) {
-    context.errors.OnError(text.loc(), "Invalid UTF-8 encoding");
+    ctx.errors.OnError(text.loc(), "Invalid UTF-8 encoding");
     return nullopt;
   }
   return text;
 }
 
-auto ReadTextList(Tokenizer& tokenizer, Context& context)
-    -> optional<TextList> {
+auto ReadTextList(Tokenizer& tokenizer, ReadCtx& ctx) -> optional<TextList> {
   TextList result;
   while (tokenizer.Peek().type == TokenType::Text) {
-    WASP_TRY_READ(text, ReadText(tokenizer, context));
+    WASP_TRY_READ(text, ReadText(tokenizer, ctx));
     result.push_back(text);
   }
   return result;
@@ -223,7 +219,7 @@ auto ReadTextList(Tokenizer& tokenizer, Context& context)
 
 // Section 1: Type
 
-auto ReadBindVarOpt(Tokenizer& tokenizer, Context& context) -> OptAt<BindVar> {
+auto ReadBindVarOpt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<BindVar> {
   auto token_opt = tokenizer.Match(TokenType::Id);
   if (!token_opt) {
     return nullopt;
@@ -234,63 +230,63 @@ auto ReadBindVarOpt(Tokenizer& tokenizer, Context& context) -> OptAt<BindVar> {
 }
 
 auto ReadBoundValueTypeList(Tokenizer& tokenizer,
-                            Context& context,
+                            ReadCtx& ctx,
                             TokenType token_type)
     -> optional<BoundValueTypeList> {
   BoundValueTypeList result;
   while (tokenizer.MatchLpar(token_type)) {
     if (tokenizer.Peek().type == TokenType::Id) {
       LocationGuard guard{tokenizer};
-      auto bind_var_opt = ReadBindVarOpt(tokenizer, context);
-      WASP_TRY_READ(value_type, ReadValueType(tokenizer, context));
+      auto bind_var_opt = ReadBindVarOpt(tokenizer, ctx);
+      WASP_TRY_READ(value_type, ReadValueType(tokenizer, ctx));
       result.push_back(
           At{guard.loc(), BoundValueType{bind_var_opt, value_type}});
     } else {
-      WASP_TRY_READ(value_types, ReadValueTypeList(tokenizer, context));
+      WASP_TRY_READ(value_types, ReadValueTypeList(tokenizer, ctx));
       for (auto& value_type : value_types) {
         result.push_back(
             At{value_type.loc(), BoundValueType{nullopt, value_type}});
       }
     }
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   }
   return result;
 }
 
-auto ReadBoundParamList(Tokenizer& tokenizer, Context& context)
+auto ReadBoundParamList(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<BoundValueTypeList> {
-  return ReadBoundValueTypeList(tokenizer, context, TokenType::Param);
+  return ReadBoundValueTypeList(tokenizer, ctx, TokenType::Param);
 }
 
 auto ReadUnboundValueTypeList(Tokenizer& tokenizer,
-                              Context& context,
+                              ReadCtx& ctx,
                               TokenType token_type) -> optional<ValueTypeList> {
   ValueTypeList result;
   while (tokenizer.MatchLpar(token_type)) {
-    WASP_TRY_READ(value_types, ReadValueTypeList(tokenizer, context));
+    WASP_TRY_READ(value_types, ReadValueTypeList(tokenizer, ctx));
     std::copy(value_types.begin(), value_types.end(),
               std::back_inserter(result));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   }
   return result;
 }
 
-auto ReadParamList(Tokenizer& tokenizer, Context& context)
+auto ReadParamList(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<ValueTypeList> {
-  return ReadUnboundValueTypeList(tokenizer, context, TokenType::Param);
+  return ReadUnboundValueTypeList(tokenizer, ctx, TokenType::Param);
 }
 
-auto ReadResultList(Tokenizer& tokenizer, Context& context)
+auto ReadResultList(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<ValueTypeList> {
-  return ReadUnboundValueTypeList(tokenizer, context, TokenType::Result);
+  return ReadUnboundValueTypeList(tokenizer, ctx, TokenType::Result);
 }
 
-auto ReadRtt(Tokenizer& tokenizer, Context& context) -> OptAt<Rtt> {
+auto ReadRtt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Rtt> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Rtt));
-  WASP_TRY_READ(depth, ReadNat32(tokenizer, context));
-  WASP_TRY_READ(type, ReadHeapType(tokenizer, context));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Rtt));
+  WASP_TRY_READ(depth, ReadNat32(tokenizer, ctx));
+  WASP_TRY_READ(type, ReadHeapType(tokenizer, ctx));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), Rtt{depth, type}};
 }
 
@@ -309,7 +305,7 @@ bool IsValueType(Tokenizer& tokenizer) {
          IsReferenceType(tokenizer);
 }
 
-auto ReadValueType(Tokenizer& tokenizer, Context& context) -> OptAt<ValueType> {
+auto ReadValueType(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<ValueType> {
   auto token = tokenizer.Peek();
   if (token.type == TokenType::NumericType) {
     assert(token.has_numeric_type());
@@ -319,11 +315,11 @@ auto ReadValueType(Tokenizer& tokenizer, Context& context) -> OptAt<ValueType> {
     bool allowed = true;
     switch (numeric_type) {
 #define WASP_V(val, Name, str)
-#define WASP_FEATURE_V(val, Name, str, feature)  \
-  case NumericType::Name:                        \
-    if (!context.features.feature##_enabled()) { \
-      allowed = false;                           \
-    }                                            \
+#define WASP_FEATURE_V(val, Name, str, feature) \
+  case NumericType::Name:                       \
+    if (!ctx.features.feature##_enabled()) {    \
+      allowed = false;                          \
+    }                                           \
     break;
 #include "wasp/base/inc/numeric_type.inc"
 #undef WASP_V
@@ -334,47 +330,47 @@ auto ReadValueType(Tokenizer& tokenizer, Context& context) -> OptAt<ValueType> {
     }
 
     if (!allowed) {
-      context.errors.OnError(
-          token.loc, concat("value type ", numeric_type, " not allowed"));
+      ctx.errors.OnError(token.loc,
+                         concat("value type ", numeric_type, " not allowed"));
       return nullopt;
     }
     return At{token.loc, ValueType{numeric_type}};
   } else if (token.type == TokenType::Lpar &&
              tokenizer.Peek(1).type == TokenType::Rtt) {
-    WASP_TRY_READ(rtt, ReadRtt(tokenizer, context));
+    WASP_TRY_READ(rtt, ReadRtt(tokenizer, ctx));
     return At{rtt.loc(), ValueType{rtt}};
   } else {
     WASP_TRY_READ(reference_type,
-                  ReadReferenceType(tokenizer, context, AllowFuncref::No));
+                  ReadReferenceType(tokenizer, ctx, AllowFuncref::No));
     return At{reference_type.loc(), ValueType{reference_type}};
   }
 }
 
-auto ReadValueTypeList(Tokenizer& tokenizer, Context& context)
+auto ReadValueTypeList(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<ValueTypeList> {
   ValueTypeList result;
   while (IsValueType(tokenizer)) {
-    WASP_TRY_READ(value, ReadValueType(tokenizer, context));
+    WASP_TRY_READ(value, ReadValueType(tokenizer, ctx));
     result.push_back(value);
   }
   return result;
 }
 
-auto ReadBoundFunctionType(Tokenizer& tokenizer, Context& context)
+auto ReadBoundFunctionType(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<BoundFunctionType> {
   LocationGuard guard{tokenizer};
-  WASP_TRY_READ(params, ReadBoundParamList(tokenizer, context));
-  WASP_TRY_READ(results, ReadResultList(tokenizer, context));
+  WASP_TRY_READ(params, ReadBoundParamList(tokenizer, ctx));
+  WASP_TRY_READ(results, ReadResultList(tokenizer, ctx));
   return At{guard.loc(), BoundFunctionType{params, results}};
 }
 
-auto ReadStorageType(Tokenizer& tokenizer, Context& context)
+auto ReadStorageType(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<StorageType> {
   if (auto token_opt = tokenizer.Match(TokenType::PackedType)) {
     assert(token_opt->has_packed_type());
     return At{token_opt->loc, StorageType{token_opt->packed_type()}};
   } else {
-    WASP_TRY_READ(value_type, ReadValueType(tokenizer, context));
+    WASP_TRY_READ(value_type, ReadValueType(tokenizer, ctx));
     return At{value_type.loc(), StorageType{value_type}};
   }
 }
@@ -386,116 +382,114 @@ bool IsFieldTypeContents(Tokenizer& tokenizer) {
          IsValueType(tokenizer) || token.type == TokenType::PackedType;
 }
 
-auto ReadFieldTypeContents(Tokenizer& tokenizer, Context& context)
+auto ReadFieldTypeContents(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<FieldType> {
   LocationGuard guard{tokenizer};
   auto token_opt = tokenizer.MatchLpar(TokenType::Mut);
-  WASP_TRY_READ(type, ReadStorageType(tokenizer, context));
+  WASP_TRY_READ(type, ReadStorageType(tokenizer, ctx));
 
   At<Mutability> mut;
   if (token_opt) {
     mut = At{token_opt->loc, Mutability::Var};
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   } else {
     mut = Mutability::Const;
   }
   return At{guard.loc(), FieldType{nullopt, type, mut}};
 }
 
-auto ReadFieldType(Tokenizer& tokenizer, Context& context) -> OptAt<FieldType> {
+auto ReadFieldType(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<FieldType> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Field));
-  auto name = ReadBindVarOpt(tokenizer, context);
-  WASP_TRY_READ(field, ReadFieldTypeContents(tokenizer, context));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Field));
+  auto name = ReadBindVarOpt(tokenizer, ctx);
+  WASP_TRY_READ(field, ReadFieldTypeContents(tokenizer, ctx));
   field->name = name;
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), field.value()};
 }
 
-auto ReadFieldTypeList(Tokenizer& tokenizer, Context& context)
+auto ReadFieldTypeList(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<FieldTypeList> {
   FieldTypeList result;
   while (tokenizer.MatchLpar(TokenType::Field)) {
     if (tokenizer.Peek().type == TokenType::Id) {
       // LPAR FIELD bind_var_opt (storagetype | LPAR MUT storagetype RPAR) RPAR
       LocationGuard guard{tokenizer};
-      auto bind_var_opt = ReadBindVarOpt(tokenizer, context);
-      WASP_TRY_READ(field, ReadFieldTypeContents(tokenizer, context));
+      auto bind_var_opt = ReadBindVarOpt(tokenizer, ctx);
+      WASP_TRY_READ(field, ReadFieldTypeContents(tokenizer, ctx));
       field->name = bind_var_opt;
       result.push_back(At{guard.loc(), field.value()});
     } else {
       // LPAR FIELD (storagetype | LPAR MUT storagetype RPAR)* RPAR
       while (IsFieldTypeContents(tokenizer)) {
-        WASP_TRY_READ(field, ReadFieldTypeContents(tokenizer, context));
+        WASP_TRY_READ(field, ReadFieldTypeContents(tokenizer, ctx));
         result.push_back(field);
       }
     }
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   }
   return result;
 }
 
-auto ReadStructType(Tokenizer& tokenizer, Context& context)
-    -> OptAt<StructType> {
+auto ReadStructType(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<StructType> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Struct));
-  WASP_TRY_READ(fields, ReadFieldTypeList(tokenizer, context));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Struct));
+  WASP_TRY_READ(fields, ReadFieldTypeList(tokenizer, ctx));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), StructType{fields}};
 }
 
-auto ReadArrayType(Tokenizer& tokenizer, Context& context) -> OptAt<ArrayType> {
+auto ReadArrayType(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<ArrayType> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Array));
-  WASP_TRY_READ(field, ReadFieldType(tokenizer, context));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Array));
+  WASP_TRY_READ(field, ReadFieldType(tokenizer, ctx));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), ArrayType{field}};
 }
 
-auto ReadDefinedType(Tokenizer& tokenizer, Context& context)
-    -> OptAt<DefinedType> {
+auto ReadDefinedType(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<DefinedType> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Type));
-  auto name = ReadBindVarOpt(tokenizer, context);
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Type));
+  auto name = ReadBindVarOpt(tokenizer, ctx);
 
   auto token = tokenizer.Peek();
   if (token.type != TokenType::Lpar) {
-    context.errors.OnError(token.loc, concat("Expected '(', got ", token.type));
+    ctx.errors.OnError(token.loc, concat("Expected '(', got ", token.type));
     return nullopt;
   }
 
   token = tokenizer.Peek(1);
   switch (token.type) {
     case TokenType::Func: {
-      WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Func));
-      WASP_TRY_READ(func_type, ReadBoundFunctionType(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Func));
+      WASP_TRY_READ(func_type, ReadBoundFunctionType(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), DefinedType{name, func_type}};
     }
 
     case TokenType::Struct: {
-      if (!context.features.gc_enabled()) {
-        context.errors.OnError(token.loc, "Structs not allowed");
+      if (!ctx.features.gc_enabled()) {
+        ctx.errors.OnError(token.loc, "Structs not allowed");
         return nullopt;
       }
-      WASP_TRY_READ(struct_type, ReadStructType(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(struct_type, ReadStructType(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), DefinedType{name, struct_type}};
     }
 
     case TokenType::Array: {
-      if (!context.features.gc_enabled()) {
-        context.errors.OnError(token.loc, "Arrays not allowed");
+      if (!ctx.features.gc_enabled()) {
+        ctx.errors.OnError(token.loc, "Arrays not allowed");
         return nullopt;
       }
-      WASP_TRY_READ(array_type, ReadArrayType(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(array_type, ReadArrayType(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), DefinedType{name, array_type}};
     }
 
     default:
-      context.errors.OnError(
+      ctx.errors.OnError(
           token.loc,
           concat("Expected `func`, `struct`, or `array`, got", token.type));
       return nullopt;
@@ -504,7 +498,7 @@ auto ReadDefinedType(Tokenizer& tokenizer, Context& context)
 
 // Section 2: Import
 
-auto ReadInlineImportOpt(Tokenizer& tokenizer, Context& context)
+auto ReadInlineImportOpt(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<InlineImport> {
   LocationGuard guard{tokenizer};
   auto import_token = tokenizer.MatchLpar(TokenType::Import);
@@ -512,133 +506,130 @@ auto ReadInlineImportOpt(Tokenizer& tokenizer, Context& context)
     return nullopt;
   }
 
-  if (context.seen_non_import) {
-    context.errors.OnError(
-        import_token->loc,
-        "Imports must occur before all non-import definitions");
+  if (ctx.seen_non_import) {
+    ctx.errors.OnError(import_token->loc,
+                       "Imports must occur before all non-import definitions");
     return nullopt;
   }
-  WASP_TRY_READ(module, ReadUtf8Text(tokenizer, context));
-  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, context));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY_READ(module, ReadUtf8Text(tokenizer, ctx));
+  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, ctx));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), InlineImport{module, name}};
 }
 
-auto ReadImport(Tokenizer& tokenizer, Context& context) -> OptAt<Import> {
+auto ReadImport(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Import> {
   LocationGuard guard{tokenizer};
-  WASP_TRY_READ(import_token,
-                ExpectLpar(tokenizer, context, TokenType::Import));
+  WASP_TRY_READ(import_token, ExpectLpar(tokenizer, ctx, TokenType::Import));
 
-  if (context.seen_non_import) {
-    context.errors.OnError(
-        import_token.loc,
-        "Imports must occur before all non-import definitions");
+  if (ctx.seen_non_import) {
+    ctx.errors.OnError(import_token.loc,
+                       "Imports must occur before all non-import definitions");
     return nullopt;
   }
 
   Import result;
-  WASP_TRY_READ(module, ReadUtf8Text(tokenizer, context));
-  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, context));
+  WASP_TRY_READ(module, ReadUtf8Text(tokenizer, ctx));
+  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, ctx));
   result.module = module;
   result.name = name;
 
-  WASP_TRY(Expect(tokenizer, context, TokenType::Lpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Lpar));
 
   auto token = tokenizer.Peek();
   switch (token.type) {
     case TokenType::Func: {
       tokenizer.Read();
-      auto name = ReadBindVarOpt(tokenizer, context);
-      auto type_use = ReadTypeUseOpt(tokenizer, context);
-      WASP_TRY_READ(type, ReadBoundFunctionType(tokenizer, context));
+      auto name = ReadBindVarOpt(tokenizer, ctx);
+      auto type_use = ReadTypeUseOpt(tokenizer, ctx);
+      WASP_TRY_READ(type, ReadBoundFunctionType(tokenizer, ctx));
       result.desc = FunctionDesc{name, type_use, type};
       break;
     }
 
     case TokenType::Table: {
       tokenizer.Read();
-      auto name = ReadBindVarOpt(tokenizer, context);
-      WASP_TRY_READ(type, ReadTableType(tokenizer, context));
+      auto name = ReadBindVarOpt(tokenizer, ctx);
+      WASP_TRY_READ(type, ReadTableType(tokenizer, ctx));
       result.desc = TableDesc{name, type};
       break;
     }
 
     case TokenType::Memory: {
       tokenizer.Read();
-      auto name = ReadBindVarOpt(tokenizer, context);
-      WASP_TRY_READ(type, ReadMemoryType(tokenizer, context));
+      auto name = ReadBindVarOpt(tokenizer, ctx);
+      WASP_TRY_READ(type, ReadMemoryType(tokenizer, ctx));
       result.desc = MemoryDesc{name, type};
       break;
     }
 
     case TokenType::Global: {
       tokenizer.Read();
-      auto name = ReadBindVarOpt(tokenizer, context);
-      WASP_TRY_READ(type, ReadGlobalType(tokenizer, context));
+      auto name = ReadBindVarOpt(tokenizer, ctx);
+      WASP_TRY_READ(type, ReadGlobalType(tokenizer, ctx));
       result.desc = GlobalDesc{name, type};
       break;
     }
 
     case TokenType::Event: {
-      if (!context.features.exceptions_enabled()) {
-        context.errors.OnError(token.loc, "Events not allowed");
+      if (!ctx.features.exceptions_enabled()) {
+        ctx.errors.OnError(token.loc, "Events not allowed");
         return nullopt;
       }
       tokenizer.Read();
-      auto name = ReadBindVarOpt(tokenizer, context);
-      WASP_TRY_READ(type, ReadEventType(tokenizer, context));
+      auto name = ReadBindVarOpt(tokenizer, ctx);
+      WASP_TRY_READ(type, ReadEventType(tokenizer, ctx));
       result.desc = EventDesc{name, type};
       break;
     }
 
     default:
-      context.errors.OnError(
+      ctx.errors.OnError(
           token.loc, concat("Expected an import external kind, got ", token));
       return nullopt;
   }
 
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), result};
 }
 
 // Section 3: Function
 
-auto ReadLocalList(Tokenizer& tokenizer, Context& context)
+auto ReadLocalList(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<BoundValueTypeList> {
-  return ReadBoundValueTypeList(tokenizer, context, TokenType::Local);
+  return ReadBoundValueTypeList(tokenizer, ctx, TokenType::Local);
 }
 
-auto ReadFunctionType(Tokenizer& tokenizer, Context& context)
+auto ReadFunctionType(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<FunctionType> {
   LocationGuard guard{tokenizer};
-  WASP_TRY_READ(params, ReadParamList(tokenizer, context));
-  WASP_TRY_READ(results, ReadResultList(tokenizer, context));
+  WASP_TRY_READ(params, ReadParamList(tokenizer, ctx));
+  WASP_TRY_READ(results, ReadResultList(tokenizer, ctx));
   return At{guard.loc(), FunctionType{params, results}};
 }
 
-auto ReadFunction(Tokenizer& tokenizer, Context& context) -> OptAt<Function> {
+auto ReadFunction(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Function> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Func));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Func));
 
   BoundValueTypeList locals;
   InstructionList instructions;
 
-  auto name = ReadBindVarOpt(tokenizer, context);
-  WASP_TRY_READ(exports, ReadInlineExportList(tokenizer, context));
-  auto import_opt = ReadInlineImportOpt(tokenizer, context);
-  context.seen_non_import |= !import_opt;
+  auto name = ReadBindVarOpt(tokenizer, ctx);
+  WASP_TRY_READ(exports, ReadInlineExportList(tokenizer, ctx));
+  auto import_opt = ReadInlineImportOpt(tokenizer, ctx);
+  ctx.seen_non_import |= !import_opt;
 
-  auto type_use = ReadTypeUseOpt(tokenizer, context);
-  WASP_TRY_READ(type, ReadBoundFunctionType(tokenizer, context));
+  auto type_use = ReadTypeUseOpt(tokenizer, ctx);
+  WASP_TRY_READ(type, ReadBoundFunctionType(tokenizer, ctx));
 
   if (!import_opt) {
-    WASP_TRY_READ(locals_, ReadLocalList(tokenizer, context));
+    WASP_TRY_READ(locals_, ReadLocalList(tokenizer, ctx));
     locals = locals_;
-    WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
-    WASP_TRY(ReadRparAsEndInstruction(tokenizer, context, instructions));
+    WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
+    WASP_TRY(ReadRparAsEndInstruction(tokenizer, ctx, instructions));
   } else {
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   }
 
   return At{guard.loc(), Function{FunctionDesc{name, type_use, type}, locals,
@@ -647,12 +638,10 @@ auto ReadFunction(Tokenizer& tokenizer, Context& context) -> OptAt<Function> {
 
 // Section 4: Table
 
-auto ReadIndexTypeOpt(Tokenizer& tokenizer, Context& context)
-    -> OptAt<IndexType> {
+auto ReadIndexTypeOpt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<IndexType> {
   LocationGuard guard{tokenizer};
   auto token = tokenizer.Peek();
-  if (context.features.memory64_enabled() &&
-      token.type == TokenType::NumericType) {
+  if (ctx.features.memory64_enabled() && token.type == TokenType::NumericType) {
     if (token.numeric_type() == NumericType::I32) {
       tokenizer.Read();
       return At{token.loc, IndexType::I32};
@@ -664,41 +653,40 @@ auto ReadIndexTypeOpt(Tokenizer& tokenizer, Context& context)
   return nullopt;
 }
 
-auto ReadLimits(Tokenizer& tokenizer, Context& context, LimitsKind kind)
+auto ReadLimits(Tokenizer& tokenizer, ReadCtx& ctx, LimitsKind kind)
     -> OptAt<Limits> {
   LocationGuard guard{tokenizer};
 
   At<IndexType> index_type = IndexType::I32;
   if (kind == LimitsKind::Memory) {
-    index_type = ReadIndexTypeOpt(tokenizer, context).value_or(IndexType::I32);
+    index_type = ReadIndexTypeOpt(tokenizer, ctx).value_or(IndexType::I32);
   }
 
-  WASP_TRY_READ(min, ReadNat32(tokenizer, context));
+  WASP_TRY_READ(min, ReadNat32(tokenizer, ctx));
   auto token = tokenizer.Peek();
   OptAt<u32> max_opt;
   if (token.type == TokenType::Nat) {
-    WASP_TRY_READ(max, ReadNat32(tokenizer, context));
+    WASP_TRY_READ(max, ReadNat32(tokenizer, ctx));
     max_opt = max;
   }
 
   token = tokenizer.Peek();
   At<Shared> shared = Shared::No;
-  if (context.features.threads_enabled() && kind == LimitsKind::Memory &&
+  if (ctx.features.threads_enabled() && kind == LimitsKind::Memory &&
       token.type == TokenType::Shared) {
     tokenizer.Read();
     shared = At{token.loc, Shared::Yes};
   }
 
   if (shared == Shared::Yes && index_type == IndexType::I64) {
-    context.errors.OnError(token.loc,
-                           "limits cannot be shared and have i64 index");
+    ctx.errors.OnError(token.loc, "limits cannot be shared and have i64 index");
     return nullopt;
   }
 
   return At{guard.loc(), Limits{min, max_opt, shared, index_type}};
 }
 
-auto ReadHeapType(Tokenizer& tokenizer, Context& context) -> OptAt<HeapType> {
+auto ReadHeapType(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<HeapType> {
   LocationGuard guard{tokenizer};
   auto token = tokenizer.Peek();
   if (token.has_heap_kind()) {
@@ -709,11 +697,11 @@ auto ReadHeapType(Tokenizer& tokenizer, Context& context) -> OptAt<HeapType> {
 
     switch (heap_kind) {
 #define WASP_V(val, Name, str)
-#define WASP_FEATURE_V(val, Name, str, feature)  \
-  case HeapKind::Name:                           \
-    if (!context.features.feature##_enabled()) { \
-      allowed = false;                           \
-    }                                            \
+#define WASP_FEATURE_V(val, Name, str, feature) \
+  case HeapKind::Name:                          \
+    if (!ctx.features.feature##_enabled()) {    \
+      allowed = false;                          \
+    }                                           \
     break;
 #include "wasp/base/inc/heap_kind.inc"
 #undef WASP_V
@@ -723,38 +711,38 @@ auto ReadHeapType(Tokenizer& tokenizer, Context& context) -> OptAt<HeapType> {
         break;
     }
     if (!allowed) {
-      context.errors.OnError(token.loc,
-                             concat("heap type ", heap_kind, " not allowed"));
+      ctx.errors.OnError(token.loc,
+                         concat("heap type ", heap_kind, " not allowed"));
       return nullopt;
     }
     return At{guard.loc(), HeapType{heap_kind}};
   } else if (IsVar(token)) {
-    WASP_TRY_READ(var, ReadVar(tokenizer, context));
+    WASP_TRY_READ(var, ReadVar(tokenizer, ctx));
     return At{guard.loc(), HeapType{var}};
   } else if (tokenizer.MatchLpar(TokenType::Type)) {
-    WASP_TRY_READ(var, ReadVar(tokenizer, context));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY_READ(var, ReadVar(tokenizer, ctx));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
     return At{guard.loc(), HeapType{var}};
   } else {
-    context.errors.OnError(token.loc,
-                           concat("Expected heap type, got ", token.type));
+    ctx.errors.OnError(token.loc,
+                       concat("Expected heap type, got ", token.type));
     return nullopt;
   }
 }
 
-auto ReadRefType(Tokenizer& tokenizer, Context& context) -> OptAt<RefType> {
+auto ReadRefType(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<RefType> {
   LocationGuard guard{tokenizer};
   Null null = Null::No;
   if (tokenizer.Match(TokenType::Null)) {
     null = Null::Yes;
   }
 
-  WASP_TRY_READ(heap_type, ReadHeapType(tokenizer, context));
+  WASP_TRY_READ(heap_type, ReadHeapType(tokenizer, ctx));
   return At{guard.loc(), RefType{heap_type, null}};
 }
 
 auto ReadReferenceType(Tokenizer& tokenizer,
-                       Context& context,
+                       ReadCtx& ctx,
                        AllowFuncref allow_funcref) -> OptAt<ReferenceType> {
   LocationGuard guard{tokenizer};
   auto token = tokenizer.Peek();
@@ -766,11 +754,11 @@ auto ReadReferenceType(Tokenizer& tokenizer,
 
     switch (reference_kind) {
 #define WASP_V(val, Name, str)
-#define WASP_FEATURE_V(val, Name, str, feature)  \
-  case ReferenceKind::Name:                      \
-    if (!context.features.feature##_enabled()) { \
-      allowed = false;                           \
-    }                                            \
+#define WASP_FEATURE_V(val, Name, str, feature) \
+  case ReferenceKind::Name:                     \
+    if (!ctx.features.feature##_enabled()) {    \
+      allowed = false;                          \
+    }                                           \
     break;
 #include "wasp/base/inc/reference_kind.inc"
 #undef WASP_V
@@ -784,74 +772,74 @@ auto ReadReferenceType(Tokenizer& tokenizer,
     // type, unless the reference types feature is enabled.
     if (reference_kind == ReferenceKind::Funcref &&
         allow_funcref == AllowFuncref::No &&
-        !context.features.reference_types_enabled()) {
+        !ctx.features.reference_types_enabled()) {
       allowed = false;
     }
 
     if (!allowed) {
-      context.errors.OnError(
+      ctx.errors.OnError(
           token.loc, concat("reference type ", reference_kind, " not allowed"));
       return nullopt;
     }
     return At{token.loc, ReferenceType{reference_kind}};
   } else if (tokenizer.MatchLpar(TokenType::Ref)) {
-    WASP_TRY_READ(ref_type, ReadRefType(tokenizer, context));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY_READ(ref_type, ReadRefType(tokenizer, ctx));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
     return At{guard.loc(), ReferenceType{ref_type}};
   } else {
-    context.errors.OnError(token.loc,
-                           concat("Expected reference type, got ", token.type));
+    ctx.errors.OnError(token.loc,
+                       concat("Expected reference type, got ", token.type));
     return nullopt;
   }
 }
 
 auto ReadReferenceTypeOpt(Tokenizer& tokenizer,
-                          Context& context,
+                          ReadCtx& ctx,
                           AllowFuncref allow_funcref) -> OptAt<ReferenceType> {
   if (!IsReferenceType(tokenizer)) {
     return nullopt;
   }
 
-  return ReadReferenceType(tokenizer, context, allow_funcref);
+  return ReadReferenceType(tokenizer, ctx, allow_funcref);
 }
 
-auto ReadTableType(Tokenizer& tokenizer, Context& context) -> OptAt<TableType> {
+auto ReadTableType(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<TableType> {
   LocationGuard guard{tokenizer};
-  WASP_TRY_READ(limits, ReadLimits(tokenizer, context, LimitsKind::Table));
-  WASP_TRY_READ(element, ReadReferenceType(tokenizer, context));
+  WASP_TRY_READ(limits, ReadLimits(tokenizer, ctx, LimitsKind::Table));
+  WASP_TRY_READ(element, ReadReferenceType(tokenizer, ctx));
   return At{guard.loc(), TableType{limits, element}};
 }
 
-auto ReadTable(Tokenizer& tokenizer, Context& context) -> OptAt<Table> {
+auto ReadTable(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Table> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Table));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Table));
 
-  auto name = ReadBindVarOpt(tokenizer, context);
-  WASP_TRY_READ(exports, ReadInlineExportList(tokenizer, context));
-  auto import_opt = ReadInlineImportOpt(tokenizer, context);
-  context.seen_non_import |= !import_opt;
+  auto name = ReadBindVarOpt(tokenizer, ctx);
+  WASP_TRY_READ(exports, ReadInlineExportList(tokenizer, ctx));
+  auto import_opt = ReadInlineImportOpt(tokenizer, ctx);
+  ctx.seen_non_import |= !import_opt;
 
-  auto elemtype_opt = ReadReferenceTypeOpt(tokenizer, context);
+  auto elemtype_opt = ReadReferenceTypeOpt(tokenizer, ctx);
   if (import_opt) {
     // Imported table.
-    WASP_TRY_READ(type, ReadTableType(tokenizer, context));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY_READ(type, ReadTableType(tokenizer, ctx));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
     return At{guard.loc(), Table{TableDesc{name, type}, *import_opt, exports}};
   } else if (elemtype_opt) {
     // Inline element segment.
-    WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Elem));
+    WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Elem));
 
     ElementList elements;
     u32 size;
-    if (context.features.bulk_memory_enabled() && IsExpression(tokenizer)) {
+    if (ctx.features.bulk_memory_enabled() && IsExpression(tokenizer)) {
       // Element expression list.
-      WASP_TRY_READ(expressions, ReadElementExpressionList(tokenizer, context));
+      WASP_TRY_READ(expressions, ReadElementExpressionList(tokenizer, ctx));
       size = static_cast<u32>(expressions.size());
       elements =
           ElementList{ElementListWithExpressions{*elemtype_opt, expressions}};
     } else {
       // Element var list.
-      WASP_TRY_READ(vars, ReadVarList(tokenizer, context));
+      WASP_TRY_READ(vars, ReadVarList(tokenizer, ctx));
       size = static_cast<u32>(vars.size());
       elements = ElementList{ElementListWithVars{ExternalKind::Function, vars}};
     }
@@ -859,13 +847,13 @@ auto ReadTable(Tokenizer& tokenizer, Context& context) -> OptAt<Table> {
     // Implicit table type.
     auto type = TableType{Limits{size, size}, *elemtype_opt};
 
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
     return At{guard.loc(), Table{TableDesc{name, type}, exports, elements}};
   } else {
     // Defined table.
-    WASP_TRY_READ(type, ReadTableType(tokenizer, context));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY_READ(type, ReadTableType(tokenizer, ctx));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
     return At{guard.loc(), Table{TableDesc{name, type}, exports}};
   }
 }
@@ -881,78 +869,74 @@ void AppendToBuffer(Buffer& buffer, const T& value) {
 }
 
 template <typename T>
-bool ReadIntsIntoBuffer(Tokenizer& tokenizer,
-                        Context& context,
-                        Buffer& buffer) {
+bool ReadIntsIntoBuffer(Tokenizer& tokenizer, ReadCtx& ctx, Buffer& buffer) {
   while (true) {
     auto token = tokenizer.Peek();
     if (!(token.type == TokenType::Nat || token.type == TokenType::Int)) {
       break;
     }
-    WASP_TRY_READ(value, ReadInt<T>(tokenizer, context));
+    WASP_TRY_READ(value, ReadInt<T>(tokenizer, ctx));
     AppendToBuffer(buffer, *value);
   }
   return true;
 }
 
 template <typename T>
-bool ReadFloatsIntoBuffer(Tokenizer& tokenizer,
-                          Context& context,
-                          Buffer& buffer) {
+bool ReadFloatsIntoBuffer(Tokenizer& tokenizer, ReadCtx& ctx, Buffer& buffer) {
   while (true) {
     auto token = tokenizer.Peek();
     if (!(token.type == TokenType::Nat || token.type == TokenType::Int ||
           token.type == TokenType::Float)) {
       break;
     }
-    WASP_TRY_READ(value, ReadFloat<T>(tokenizer, context));
+    WASP_TRY_READ(value, ReadFloat<T>(tokenizer, ctx));
     AppendToBuffer(buffer, *value);
   }
   return true;
 }
 
-auto ReadSimdConst(Tokenizer& tokenizer, Context& context) -> OptAt<v128> {
+auto ReadSimdConst(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<v128> {
   auto shape_token = tokenizer.Match(TokenType::SimdShape);
   if (!shape_token) {
-    context.errors.OnError(shape_token->loc, concat("Invalid SIMD shape, got ",
-                                                    tokenizer.Peek().type));
+    ctx.errors.OnError(shape_token->loc, concat("Invalid SIMD shape, got ",
+                                                tokenizer.Peek().type));
     return nullopt;
   }
 
   At<v128> literal;
   switch (shape_token->simd_shape()) {
     case SimdShape::I8X16: {
-      WASP_TRY_READ(literal_, (ReadSimdValues<u8, 16>(tokenizer, context)));
+      WASP_TRY_READ(literal_, (ReadSimdValues<u8, 16>(tokenizer, ctx)));
       literal = literal_;
       break;
     }
 
     case SimdShape::I16X8: {
-      WASP_TRY_READ(literal_, (ReadSimdValues<u16, 8>(tokenizer, context)));
+      WASP_TRY_READ(literal_, (ReadSimdValues<u16, 8>(tokenizer, ctx)));
       literal = literal_;
       break;
     }
 
     case SimdShape::I32X4: {
-      WASP_TRY_READ(literal_, (ReadSimdValues<u32, 4>(tokenizer, context)));
+      WASP_TRY_READ(literal_, (ReadSimdValues<u32, 4>(tokenizer, ctx)));
       literal = literal_;
       break;
     }
 
     case SimdShape::I64X2: {
-      WASP_TRY_READ(literal_, (ReadSimdValues<u64, 2>(tokenizer, context)));
+      WASP_TRY_READ(literal_, (ReadSimdValues<u64, 2>(tokenizer, ctx)));
       literal = literal_;
       break;
     }
 
     case SimdShape::F32X4: {
-      WASP_TRY_READ(literal_, (ReadSimdValues<f32, 4>(tokenizer, context)));
+      WASP_TRY_READ(literal_, (ReadSimdValues<f32, 4>(tokenizer, ctx)));
       literal = literal_;
       break;
     }
 
     case SimdShape::F64X2: {
-      WASP_TRY_READ(literal_, (ReadSimdValues<f64, 2>(tokenizer, context)));
+      WASP_TRY_READ(literal_, (ReadSimdValues<f64, 2>(tokenizer, ctx)));
       literal = literal_;
       break;
     }
@@ -965,22 +949,21 @@ auto ReadSimdConst(Tokenizer& tokenizer, Context& context) -> OptAt<v128> {
 }
 
 bool ReadSimdConstsIntoBuffer(Tokenizer& tokenizer,
-                              Context& context,
+                              ReadCtx& ctx,
                               Buffer& buffer) {
   while (true) {
     if (tokenizer.Peek().type != TokenType::SimdShape) {
       break;
     }
-    WASP_TRY_READ(value, ReadSimdConst(tokenizer, context));
+    WASP_TRY_READ(value, ReadSimdConst(tokenizer, ctx));
     AppendToBuffer(buffer, *value);
   }
   return true;
 }
 
-auto ReadNumericData(Tokenizer& tokenizer, Context& context)
-    -> OptAt<NumericData> {
+auto ReadNumericData(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<NumericData> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(Expect(tokenizer, context, TokenType::Lpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Lpar));
 
   NumericDataType type;
   Buffer buffer;
@@ -990,23 +973,23 @@ auto ReadNumericData(Tokenizer& tokenizer, Context& context)
     switch (token.numeric_type()) {
       case NumericType::I32:
         type = NumericDataType::I32;
-        WASP_TRY(ReadIntsIntoBuffer<s32>(tokenizer, context, buffer));
+        WASP_TRY(ReadIntsIntoBuffer<s32>(tokenizer, ctx, buffer));
         break;
       case NumericType::I64:
         type = NumericDataType::I64;
-        WASP_TRY(ReadIntsIntoBuffer<s64>(tokenizer, context, buffer));
+        WASP_TRY(ReadIntsIntoBuffer<s64>(tokenizer, ctx, buffer));
         break;
       case NumericType::F32:
         type = NumericDataType::F32;
-        WASP_TRY(ReadFloatsIntoBuffer<f32>(tokenizer, context, buffer));
+        WASP_TRY(ReadFloatsIntoBuffer<f32>(tokenizer, ctx, buffer));
         break;
       case NumericType::F64:
         type = NumericDataType::F64;
-        WASP_TRY(ReadFloatsIntoBuffer<f64>(tokenizer, context, buffer));
+        WASP_TRY(ReadFloatsIntoBuffer<f64>(tokenizer, ctx, buffer));
         break;
       case NumericType::V128:
         type = NumericDataType::V128;
-        WASP_TRY(ReadSimdConstsIntoBuffer(tokenizer, context, buffer));
+        WASP_TRY(ReadSimdConstsIntoBuffer(tokenizer, ctx, buffer));
         break;
       default:
         WASP_UNREACHABLE();
@@ -1016,21 +999,21 @@ auto ReadNumericData(Tokenizer& tokenizer, Context& context)
     switch (token.packed_type()) {
       case PackedType::I8:
         type = NumericDataType::I8;
-        WASP_TRY(ReadIntsIntoBuffer<s8>(tokenizer, context, buffer));
+        WASP_TRY(ReadIntsIntoBuffer<s8>(tokenizer, ctx, buffer));
         break;
       case PackedType::I16:
         type = NumericDataType::I16;
-        WASP_TRY(ReadIntsIntoBuffer<s16>(tokenizer, context, buffer));
+        WASP_TRY(ReadIntsIntoBuffer<s16>(tokenizer, ctx, buffer));
         break;
       default:
         WASP_UNREACHABLE();
     }
   } else {
-    context.errors.OnError(
-        token.loc, "Expected a numeric type: i8, i16, i32, i64, f32, f64");
+    ctx.errors.OnError(token.loc,
+                       "Expected a numeric type: i8, i16, i32, i64, f32, f64");
     return nullopt;
   }
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), NumericData{type, std::move(buffer)}};
 }
 
@@ -1042,64 +1025,63 @@ bool IsDataItem(Tokenizer& tokenizer) {
            tokenizer.Peek(1).type == TokenType::NumericType));
 }
 
-auto ReadDataItem(Tokenizer& tokenizer, Context& context) -> OptAt<DataItem> {
+auto ReadDataItem(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<DataItem> {
   auto token = tokenizer.Peek();
   if (token.type == TokenType::Text) {
     tokenizer.Read();
     return At{token.loc, DataItem{token.text()}};
-  } else if (context.features.numeric_values_enabled()) {
-    WASP_TRY_READ(numeric_data, ReadNumericData(tokenizer, context));
+  } else if (ctx.features.numeric_values_enabled()) {
+    WASP_TRY_READ(numeric_data, ReadNumericData(tokenizer, ctx));
     return At{numeric_data.loc(), DataItem{numeric_data}};
   } else {
-    context.errors.OnError(token.loc, "Numeric values not allowed");
+    ctx.errors.OnError(token.loc, "Numeric values not allowed");
     return nullopt;
   }
 }
 
-auto ReadDataItemList(Tokenizer& tokenizer, Context& context)
+auto ReadDataItemList(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<DataItemList> {
   DataItemList result;
   while (IsDataItem(tokenizer)) {
-    WASP_TRY_READ(value, ReadDataItem(tokenizer, context));
+    WASP_TRY_READ(value, ReadDataItem(tokenizer, ctx));
     result.push_back(value);
   }
   return result;
 }
 
-auto ReadMemoryType(Tokenizer& tokenizer, Context& context)
-    -> OptAt<MemoryType> {
-  WASP_TRY_READ(limits, ReadLimits(tokenizer, context, LimitsKind::Memory));
+auto ReadMemoryType(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<MemoryType> {
+  WASP_TRY_READ(limits, ReadLimits(tokenizer, ctx, LimitsKind::Memory));
   return At{limits.loc(), MemoryType{limits}};
 }
 
-auto ReadMemory(Tokenizer& tokenizer, Context& context) -> OptAt<Memory> {
+auto ReadMemory(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Memory> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Memory));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Memory));
 
-  auto name = ReadBindVarOpt(tokenizer, context);
-  WASP_TRY_READ(exports, ReadInlineExportList(tokenizer, context));
-  auto import_opt = ReadInlineImportOpt(tokenizer, context);
-  context.seen_non_import |= !import_opt;
+  auto name = ReadBindVarOpt(tokenizer, ctx);
+  WASP_TRY_READ(exports, ReadInlineExportList(tokenizer, ctx));
+  auto import_opt = ReadInlineImportOpt(tokenizer, ctx);
+  ctx.seen_non_import |= !import_opt;
 
   if (import_opt) {
     // Imported memory.
-    WASP_TRY_READ(type, ReadMemoryType(tokenizer, context));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY_READ(type, ReadMemoryType(tokenizer, ctx));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
     return At{guard.loc(),
               Memory{MemoryDesc{name, type}, *import_opt, exports}};
   } else {
     // MEMORY * index_type? LPAR DATA ...
     // MEMORY * index_type? nat ...
-    if ((context.features.memory64_enabled() &&
+    if ((ctx.features.memory64_enabled() &&
          tokenizer.Peek().type == TokenType::NumericType &&
          tokenizer.Peek(1).type == TokenType::Lpar) ||
         tokenizer.Peek().type == TokenType::Lpar) {
       // Inline data segment.
       auto index_type =
-          ReadIndexTypeOpt(tokenizer, context).value_or(IndexType::I32);
-      WASP_TRY(Expect(tokenizer, context, TokenType::Lpar));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Data));
-      WASP_TRY_READ(data, ReadDataItemList(tokenizer, context));
+          ReadIndexTypeOpt(tokenizer, ctx).value_or(IndexType::I32);
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Lpar));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Data));
+      WASP_TRY_READ(data, ReadDataItemList(tokenizer, ctx));
       auto size = std::accumulate(
           data.begin(), data.end(), u32{0},
           [](u32 total, DataItem item) { return total + item.byte_size(); });
@@ -1107,13 +1089,13 @@ auto ReadMemory(Tokenizer& tokenizer, Context& context) -> OptAt<Memory> {
       // Implicit memory type.
       auto type = MemoryType{Limits{size, size, Shared::No, index_type}};
 
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Memory{MemoryDesc{name, type}, exports, data}};
     } else {
       // Defined memory.
-      WASP_TRY_READ(type, ReadMemoryType(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(type, ReadMemoryType(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Memory{MemoryDesc{name, type}, exports}};
     }
   }
@@ -1121,85 +1103,84 @@ auto ReadMemory(Tokenizer& tokenizer, Context& context) -> OptAt<Memory> {
 
 // Section 6: Global
 
-auto ReadConstantExpression(Tokenizer& tokenizer, Context& context)
+auto ReadConstantExpression(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<ConstantExpression> {
   LocationGuard guard{tokenizer};
   InstructionList instructions;
-  WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
+  WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
   return At{guard.loc(), ConstantExpression{instructions}};
 }
 
-auto ReadGlobalType(Tokenizer& tokenizer, Context& context)
-    -> OptAt<GlobalType> {
+auto ReadGlobalType(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<GlobalType> {
   LocationGuard guard{tokenizer};
 
   auto token_opt = tokenizer.MatchLpar(TokenType::Mut);
-  WASP_TRY_READ(valtype, ReadValueType(tokenizer, context));
+  WASP_TRY_READ(valtype, ReadValueType(tokenizer, ctx));
 
   At<Mutability> mut;
   if (token_opt) {
     mut = At{token_opt->loc, Mutability::Var};
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   } else {
     mut = Mutability::Const;
   }
   return At{guard.loc(), GlobalType{valtype, mut}};
 }
 
-auto ReadGlobal(Tokenizer& tokenizer, Context& context) -> OptAt<Global> {
+auto ReadGlobal(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Global> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Global));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Global));
 
-  auto name = ReadBindVarOpt(tokenizer, context);
-  WASP_TRY_READ(exports, ReadInlineExportList(tokenizer, context));
-  auto import_opt = ReadInlineImportOpt(tokenizer, context);
-  context.seen_non_import |= !import_opt;
+  auto name = ReadBindVarOpt(tokenizer, ctx);
+  WASP_TRY_READ(exports, ReadInlineExportList(tokenizer, ctx));
+  auto import_opt = ReadInlineImportOpt(tokenizer, ctx);
+  ctx.seen_non_import |= !import_opt;
 
-  WASP_TRY_READ(type, ReadGlobalType(tokenizer, context));
+  WASP_TRY_READ(type, ReadGlobalType(tokenizer, ctx));
 
   At<ConstantExpression> init;
   if (!import_opt) {
-    WASP_TRY_READ(init_, ReadConstantExpression(tokenizer, context));
+    WASP_TRY_READ(init_, ReadConstantExpression(tokenizer, ctx));
     init = init_;
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
     return At{guard.loc(), Global{GlobalDesc{name, type}, init, exports}};
   }
 
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), Global{GlobalDesc{name, type}, *import_opt, exports}};
 }
 
 // Section 7: Export
 
-auto ReadInlineExport(Tokenizer& tokenizer, Context& context)
+auto ReadInlineExport(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<InlineExport> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Export));
-  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, context));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Export));
+  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, ctx));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), InlineExport{name}};
 }
 
-auto ReadInlineExportList(Tokenizer& tokenizer, Context& context)
+auto ReadInlineExportList(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<InlineExportList> {
   InlineExportList result;
   while (tokenizer.Peek().type == TokenType::Lpar &&
          tokenizer.Peek(1).type == TokenType::Export) {
-    WASP_TRY_READ(export_, ReadInlineExport(tokenizer, context));
+    WASP_TRY_READ(export_, ReadInlineExport(tokenizer, ctx));
     result.push_back(export_);
   }
   return result;
 }
 
-auto ReadExport(Tokenizer& tokenizer, Context& context) -> OptAt<Export> {
+auto ReadExport(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Export> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Export));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Export));
 
-  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, context));
+  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, ctx));
 
   At<ExternalKind> kind;
 
-  WASP_TRY(Expect(tokenizer, context, TokenType::Lpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Lpar));
   auto token = tokenizer.Peek();
   switch (token.type) {
     case TokenType::Func:
@@ -1219,67 +1200,67 @@ auto ReadExport(Tokenizer& tokenizer, Context& context) -> OptAt<Export> {
       break;
 
     case TokenType::Event:
-      if (!context.features.exceptions_enabled()) {
-        context.errors.OnError(token.loc, "Events not allowed");
+      if (!ctx.features.exceptions_enabled()) {
+        ctx.errors.OnError(token.loc, "Events not allowed");
         return nullopt;
       }
       kind = At{token.loc, ExternalKind::Event};
       break;
 
     default:
-      context.errors.OnError(
+      ctx.errors.OnError(
           token.loc,
           concat("Expected an import external kind, got ", token.type));
       return nullopt;
   }
 
   tokenizer.Read();
-  WASP_TRY_READ(var, ReadVar(tokenizer, context));
+  WASP_TRY_READ(var, ReadVar(tokenizer, ctx));
 
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
 
   return At{guard.loc(), Export{kind, name, var}};
 }
 
 // Section 8: Start
 
-auto ReadStart(Tokenizer& tokenizer, Context& context) -> OptAt<Start> {
+auto ReadStart(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Start> {
   LocationGuard guard{tokenizer};
-  WASP_TRY_READ(start_token, ExpectLpar(tokenizer, context, TokenType::Start));
+  WASP_TRY_READ(start_token, ExpectLpar(tokenizer, ctx, TokenType::Start));
 
-  if (context.seen_start) {
-    context.errors.OnError(start_token.loc, "Multiple start functions");
+  if (ctx.seen_start) {
+    ctx.errors.OnError(start_token.loc, "Multiple start functions");
     return nullopt;
   }
-  context.seen_start = true;
+  ctx.seen_start = true;
 
-  WASP_TRY_READ(var, ReadVar(tokenizer, context));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY_READ(var, ReadVar(tokenizer, ctx));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), Start{var}};
 }
 
 // Section 9: Elem
 
-auto ReadOffsetExpression(Tokenizer& tokenizer, Context& context)
+auto ReadOffsetExpression(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<ConstantExpression> {
   LocationGuard guard{tokenizer};
   InstructionList instructions;
   if (tokenizer.MatchLpar(TokenType::Offset)) {
-    WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   } else if (IsExpression(tokenizer)) {
-    WASP_TRY(ReadExpression(tokenizer, context, instructions));
+    WASP_TRY(ReadExpression(tokenizer, ctx, instructions));
   } else {
     auto token = tokenizer.Peek();
-    context.errors.OnError(
-        token.loc, concat("Expected offset expression, got ", token.type));
+    ctx.errors.OnError(token.loc,
+                       concat("Expected offset expression, got ", token.type));
     return nullopt;
   }
   return At{guard.loc(), ConstantExpression{instructions}};
 }
 
-auto ReadElementExpression(Tokenizer& tokenizer, Context& context)
+auto ReadElementExpression(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<ElementExpression> {
   LocationGuard guard{tokenizer};
   InstructionList instructions;
@@ -1287,60 +1268,60 @@ auto ReadElementExpression(Tokenizer& tokenizer, Context& context)
   // Element expressions were first added in the bulk memory proposal, so it
   // shouldn't be read (and this function shouldn't be called) if that feature
   // is not enabled.
-  assert(context.features.bulk_memory_enabled());
+  assert(ctx.features.bulk_memory_enabled());
   // The only valid instructions are enabled by the reference types proposal,
   // but their encoding is still used by the bulk memory proposal.
   Features new_features;
   new_features.enable_reference_types();
-  Context new_context{new_features, context.errors};
+  ReadCtx new_context{new_features, ctx.errors};
 
   if (tokenizer.MatchLpar(TokenType::Item)) {
     WASP_TRY(ReadInstructionList(tokenizer, new_context, instructions));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   } else if (IsExpression(tokenizer)) {
     WASP_TRY(ReadExpression(tokenizer, new_context, instructions));
   } else {
     auto token = tokenizer.Peek();
-    context.errors.OnError(
-        token.loc, concat("Expected element expression, got ", token.type));
+    ctx.errors.OnError(token.loc,
+                       concat("Expected element expression, got ", token.type));
     return nullopt;
   }
   return At{guard.loc(), ElementExpression{instructions}};
 }
 
-auto ReadElementExpressionList(Tokenizer& tokenizer, Context& context)
+auto ReadElementExpressionList(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<ElementExpressionList> {
   ElementExpressionList result;
   while (IsElementExpression(tokenizer)) {
-    WASP_TRY_READ(expression, ReadElementExpression(tokenizer, context));
+    WASP_TRY_READ(expression, ReadElementExpression(tokenizer, ctx));
     result.push_back(expression);
   }
   return result;
 }
 
-auto ReadTableUseOpt(Tokenizer& tokenizer, Context& context) -> OptAt<Var> {
-  return ReadVarUseOpt(tokenizer, context, TokenType::Table);
+auto ReadTableUseOpt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Var> {
+  return ReadVarUseOpt(tokenizer, ctx, TokenType::Table);
 }
 
-auto ReadElementSegment(Tokenizer& tokenizer, Context& context)
+auto ReadElementSegment(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<ElementSegment> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Elem));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Elem));
 
-  if (context.features.bulk_memory_enabled()) {
+  if (ctx.features.bulk_memory_enabled()) {
     // LPAR ELEM * bind_var_opt elem_list RPAR
     // LPAR ELEM * bind_var_opt table_use offset elem_list RPAR
     // LPAR ELEM * bind_var_opt DECLARE elem_list RPAR
     // LPAR ELEM * bind_var_opt offset elem_list RPAR  /* Sugar */
     // LPAR ELEM * bind_var_opt offset elem_var_list RPAR  /* Sugar */
-    auto name = ReadBindVarOpt(tokenizer, context);
-    auto table_use_opt = ReadTableUseOpt(tokenizer, context);
+    auto name = ReadBindVarOpt(tokenizer, ctx);
+    auto table_use_opt = ReadTableUseOpt(tokenizer, ctx);
 
     SegmentType segment_type;
     OptAt<ConstantExpression> offset_opt;
     if (table_use_opt) {
       // LPAR ELEM bind_var_opt table_use * offset elem_list RPAR
-      WASP_TRY_READ(offset, ReadOffsetExpression(tokenizer, context));
+      WASP_TRY_READ(offset, ReadOffsetExpression(tokenizer, ctx));
       offset_opt = offset;
       segment_type = SegmentType::Active;
     } else {
@@ -1354,15 +1335,15 @@ auto ReadElementSegment(Tokenizer& tokenizer, Context& context)
         segment_type = SegmentType::Active;
         // LPAR ELEM bind_var_opt * offset elem_list RPAR
         // LPAR ELEM bind_var_opt * offset elem_var_list RPAR
-        WASP_TRY_READ(offset, ReadOffsetExpression(tokenizer, context));
+        WASP_TRY_READ(offset, ReadOffsetExpression(tokenizer, ctx));
         offset_opt = offset;
 
         token = tokenizer.Peek();
         if (token.type == TokenType::Nat || token.type == TokenType::Id ||
             token.type == TokenType::Rpar) {
           // LPAR ELEM bind_var_opt offset * elem_var_list RPAR
-          WASP_TRY_READ(init, ReadVarList(tokenizer, context));
-          WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+          WASP_TRY_READ(init, ReadVarList(tokenizer, ctx));
+          WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
           return At{guard.loc(),
                     ElementSegment{
                         name, nullopt, *offset_opt,
@@ -1381,8 +1362,8 @@ auto ReadElementSegment(Tokenizer& tokenizer, Context& context)
       tokenizer.Read();
       // * elem_kind elem_var_list
       auto kind = At{token.loc, ExternalKind::Function};
-      WASP_TRY_READ(init, ReadVarList(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(init, ReadVarList(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
 
       if (segment_type == SegmentType::Active) {
         assert(offset_opt.has_value());
@@ -1394,9 +1375,9 @@ auto ReadElementSegment(Tokenizer& tokenizer, Context& context)
       }
     } else {
       // * ref_type elem_expr_list
-      WASP_TRY_READ(elemtype, ReadReferenceType(tokenizer, context));
-      WASP_TRY_READ(init, ReadElementExpressionList(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(elemtype, ReadReferenceType(tokenizer, ctx));
+      WASP_TRY_READ(init, ReadElementExpressionList(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
 
       if (segment_type == SegmentType::Active) {
         assert(offset_opt.has_value());
@@ -1412,10 +1393,10 @@ auto ReadElementSegment(Tokenizer& tokenizer, Context& context)
   } else {
     // LPAR ELEM * var offset var_list RPAR
     // LPAR ELEM * offset var_list RPAR  /* Sugar */
-    auto table = ReadVarOpt(tokenizer, context);
-    WASP_TRY_READ(offset, ReadOffsetExpression(tokenizer, context));
-    WASP_TRY_READ(init, ReadVarList(tokenizer, context));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    auto table = ReadVarOpt(tokenizer, ctx);
+    WASP_TRY_READ(offset, ReadOffsetExpression(tokenizer, ctx));
+    WASP_TRY_READ(init, ReadVarList(tokenizer, ctx));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
     return At{guard.loc(), ElementSegment{nullopt, table, offset,
                                           ElementListWithVars{
                                               ExternalKind::Function, init}}};
@@ -1425,7 +1406,7 @@ auto ReadElementSegment(Tokenizer& tokenizer, Context& context)
 // Section 10: Code
 
 auto ReadNameEqNatOpt(Tokenizer& tokenizer,
-                      Context& context,
+                      ReadCtx& ctx,
                       TokenType token_type,
                       u32 offset) -> OptAt<u32> {
   auto token_opt = tokenizer.Match(token_type);
@@ -1436,71 +1417,69 @@ auto ReadNameEqNatOpt(Tokenizer& tokenizer,
   auto nat_opt = StrToNat<u32>(token_opt->literal_info(),
                                token_opt->span_u8().subspan(offset));
   if (!nat_opt) {
-    context.errors.OnError(
-        token_opt->loc,
-        concat("Invalid natural number, got ", token_opt->type));
+    ctx.errors.OnError(token_opt->loc,
+                       concat("Invalid natural number, got ", token_opt->type));
     return nullopt;
   }
 
   return At{token_opt->loc, *nat_opt};
 }
 
-auto ReadAlignOpt(Tokenizer& tokenizer, Context& context) -> OptAt<u32> {
-  auto nat_opt = ReadNameEqNatOpt(tokenizer, context, TokenType::AlignEqNat, 6);
+auto ReadAlignOpt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<u32> {
+  auto nat_opt = ReadNameEqNatOpt(tokenizer, ctx, TokenType::AlignEqNat, 6);
   if (!nat_opt) {
     return nullopt;
   }
 
   auto value = nat_opt->value();
   if (value == 0 || (value & (value - 1)) != 0) {
-    context.errors.OnError(
-        nat_opt->loc(),
-        concat("Alignment must be a power of two, got ", value));
+    ctx.errors.OnError(nat_opt->loc(),
+                       concat("Alignment must be a power of two, got ", value));
     return nullopt;
   }
   return nat_opt;
 }
 
-auto ReadOffsetOpt(Tokenizer& tokenizer, Context& context) -> OptAt<u32> {
-  return ReadNameEqNatOpt(tokenizer, context, TokenType::OffsetEqNat, 7);
+auto ReadOffsetOpt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<u32> {
+  return ReadNameEqNatOpt(tokenizer, ctx, TokenType::OffsetEqNat, 7);
 }
 
-auto ReadSimdLane(Tokenizer& tokenizer, Context& context) -> OptAt<u8> {
-  return ReadNat<u8>(tokenizer, context);
+auto ReadSimdLane(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<u8> {
+  return ReadNat<u8>(tokenizer, ctx);
 }
 
-auto ReadSimdShuffleImmediate(Tokenizer& tokenizer, Context& context)
+auto ReadSimdShuffleImmediate(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<ShuffleImmediate> {
   LocationGuard guard{tokenizer};
   ShuffleImmediate result;
   for (size_t lane = 0; lane < result.size(); ++lane) {
-    WASP_TRY_READ(value, ReadSimdLane(tokenizer, context));
+    WASP_TRY_READ(value, ReadSimdLane(tokenizer, ctx));
     result[lane] = value;
   }
   return At{guard.loc(), result};
 }
 
 template <typename T, size_t N>
-auto ReadSimdValues(Tokenizer& tokenizer, Context& context) -> OptAt<v128> {
+auto ReadSimdValues(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<v128> {
   LocationGuard guard{tokenizer};
   std::array<T, N> result;
   for (size_t lane = 0; lane < N; ++lane) {
     if constexpr (std::is_floating_point_v<T>) {
-      WASP_TRY_READ(float_, ReadFloat<T>(tokenizer, context));
+      WASP_TRY_READ(float_, ReadFloat<T>(tokenizer, ctx));
       result[lane] = float_;
     } else {
-      WASP_TRY_READ(int_, ReadInt<T>(tokenizer, context));
+      WASP_TRY_READ(int_, ReadInt<T>(tokenizer, ctx));
       result[lane] = int_;
     }
   }
   return At{guard.loc(), v128{result}};
 }
 
-auto ReadHeapType2Immediate(Tokenizer& tokenizer, Context& context)
+auto ReadHeapType2Immediate(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<HeapType2Immediate> {
   LocationGuard guard{tokenizer};
-  WASP_TRY_READ(ht1, ReadHeapType(tokenizer, context));
-  WASP_TRY_READ(ht2, ReadHeapType(tokenizer, context));
+  WASP_TRY_READ(ht1, ReadHeapType(tokenizer, ctx));
+  WASP_TRY_READ(ht2, ReadHeapType(tokenizer, ctx));
   return At{guard.loc(), HeapType2Immediate{ht1, ht2}};
 }
 
@@ -1565,43 +1544,43 @@ bool IsElementExpression(Tokenizer& tokenizer) {
                                      tokenizer.Peek(1).type == TokenType::Item);
 }
 
-bool CheckOpcodeEnabled(Token token, Context& context) {
+bool CheckOpcodeEnabled(Token token, ReadCtx& ctx) {
   assert(token.has_opcode());
-  if (!context.features.HasFeatures(Features{token.opcode_features()})) {
-    context.errors.OnError(token.loc,
-                           concat(token.opcode(), " instruction not allowed"));
+  if (!ctx.features.HasFeatures(Features{token.opcode_features()})) {
+    ctx.errors.OnError(token.loc,
+                       concat(token.opcode(), " instruction not allowed"));
     return false;
   }
   return true;
 }
 
-auto ReadPlainInstruction(Tokenizer& tokenizer, Context& context)
+auto ReadPlainInstruction(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<Instruction> {
   LocationGuard guard{tokenizer};
   auto token = tokenizer.Peek();
   switch (token.type) {
     case TokenType::BareInstr:
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       return At{token.loc, Instruction{token.opcode()}};
 
     case TokenType::HeapTypeInstr:
     case TokenType::RefNullInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
-      WASP_TRY_READ(type, ReadHeapType(tokenizer, context));
+      WASP_TRY_READ(type, ReadHeapType(tokenizer, ctx));
       return At{guard.loc(), Instruction{token.opcode(), type}};
     }
 
     case TokenType::BrOnCastInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       LocationGuard immediate_guard{tokenizer};
-      WASP_TRY_READ(var, ReadVar(tokenizer, context));
+      WASP_TRY_READ(var, ReadVar(tokenizer, ctx));
       // TODO: Determine whether this instruction should have heap type
       // immediates.
 #if 0
-      WASP_TRY_READ(types, ReadHeapType2Immediate(tokenizer, context));
+      WASP_TRY_READ(types, ReadHeapType2Immediate(tokenizer, ctx));
       auto immediate = At{immediate_guard.loc(), BrOnCastImmediate{var, types}};
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
 #else
@@ -1610,21 +1589,21 @@ auto ReadPlainInstruction(Tokenizer& tokenizer, Context& context)
     }
 
     case TokenType::BrOnExnInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       LocationGuard immediate_guard{tokenizer};
-      WASP_TRY_READ(label_var, ReadVar(tokenizer, context));
-      WASP_TRY_READ(exn_var, ReadVar(tokenizer, context));
+      WASP_TRY_READ(label_var, ReadVar(tokenizer, ctx));
+      WASP_TRY_READ(exn_var, ReadVar(tokenizer, ctx));
       auto immediate =
           At{immediate_guard.loc(), BrOnExnImmediate{label_var, exn_var}};
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::BrTableInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       LocationGuard immediate_guard{tokenizer};
-      WASP_TRY_READ(var_list, ReadNonEmptyVarList(tokenizer, context));
+      WASP_TRY_READ(var_list, ReadNonEmptyVarList(tokenizer, ctx));
       auto default_target = var_list.back();
       var_list.pop_back();
       auto immediate =
@@ -1633,114 +1612,114 @@ auto ReadPlainInstruction(Tokenizer& tokenizer, Context& context)
     }
 
     case TokenType::CallIndirectInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       LocationGuard immediate_guard{tokenizer};
       OptAt<Var> table_var_opt;
-      if (context.features.reference_types_enabled()) {
-        table_var_opt = ReadVarOpt(tokenizer, context);
+      if (ctx.features.reference_types_enabled()) {
+        table_var_opt = ReadVarOpt(tokenizer, ctx);
       }
-      WASP_TRY_READ(type, ReadFunctionTypeUse(tokenizer, context));
+      WASP_TRY_READ(type, ReadFunctionTypeUse(tokenizer, ctx));
       auto immediate =
           At{immediate_guard.loc(), CallIndirectImmediate{table_var_opt, type}};
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::F32ConstInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
-      WASP_TRY_READ(immediate, ReadFloat<f32>(tokenizer, context));
+      WASP_TRY_READ(immediate, ReadFloat<f32>(tokenizer, ctx));
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::F64ConstInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
-      WASP_TRY_READ(immediate, ReadFloat<f64>(tokenizer, context));
+      WASP_TRY_READ(immediate, ReadFloat<f64>(tokenizer, ctx));
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::FuncBindInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       LocationGuard immediate_guard{tokenizer};
-      WASP_TRY_READ(type, ReadFunctionTypeUse(tokenizer, context));
+      WASP_TRY_READ(type, ReadFunctionTypeUse(tokenizer, ctx));
       auto immediate = At{immediate_guard.loc(), FuncBindImmediate{type}};
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::HeapType2Instr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
-      WASP_TRY_READ(immediate, ReadHeapType2Immediate(tokenizer, context));
+      WASP_TRY_READ(immediate, ReadHeapType2Immediate(tokenizer, ctx));
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::I32ConstInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
-      WASP_TRY_READ(immediate, ReadInt<s32>(tokenizer, context));
+      WASP_TRY_READ(immediate, ReadInt<s32>(tokenizer, ctx));
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::I64ConstInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
-      WASP_TRY_READ(immediate, ReadInt<s64>(tokenizer, context));
+      WASP_TRY_READ(immediate, ReadInt<s64>(tokenizer, ctx));
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::MemoryInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       LocationGuard immediate_guard{tokenizer};
-      auto offset_opt = ReadOffsetOpt(tokenizer, context);
-      auto align_opt = ReadAlignOpt(tokenizer, context);
+      auto offset_opt = ReadOffsetOpt(tokenizer, ctx);
+      auto align_opt = ReadAlignOpt(tokenizer, ctx);
       auto immediate =
           At{immediate_guard.loc(), MemArgImmediate{align_opt, offset_opt}};
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::MemoryCopyInstr:
-      CheckOpcodeEnabled(token, context);
+      CheckOpcodeEnabled(token, ctx);
       tokenizer.Read();
       return At{guard.loc(), Instruction{token.opcode(), CopyImmediate{}}};
 
     case TokenType::MemoryInitInstr: {
-      CheckOpcodeEnabled(token, context);
+      CheckOpcodeEnabled(token, ctx);
       tokenizer.Read();
       LocationGuard immediate_guard{tokenizer};
-      WASP_TRY_READ(segment_var, ReadVar(tokenizer, context));
+      WASP_TRY_READ(segment_var, ReadVar(tokenizer, ctx));
       auto immediate =
           At{immediate_guard.loc(), InitImmediate{segment_var, nullopt}};
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::RttSubInstr: {
-      CheckOpcodeEnabled(token, context);
+      CheckOpcodeEnabled(token, ctx);
       tokenizer.Read();
       LocationGuard immediate_guard{tokenizer};
       // TODO: Determine whether this instruction should have heap type
       // immediates.
 #if 0
-      WASP_TRY_READ(depth, ReadNat32(tokenizer, context));
-      WASP_TRY_READ(types, ReadHeapType2Immediate(tokenizer, context));
+      WASP_TRY_READ(depth, ReadNat32(tokenizer, ctx));
+      WASP_TRY_READ(types, ReadHeapType2Immediate(tokenizer, ctx));
       auto immediate = At{immediate_guard.loc(), RttSubImmediate{depth, types}};
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
 #else
-      WASP_TRY_READ(type, ReadHeapType(tokenizer, context));
+      WASP_TRY_READ(type, ReadHeapType(tokenizer, ctx));
       return At{guard.loc(), Instruction{token.opcode(), type}};
 #endif
     }
 
     case TokenType::SelectInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       At<Opcode> opcode = token.opcode();
       At<ValueTypeList> immediate;
-      if (context.features.reference_types_enabled()) {
+      if (ctx.features.reference_types_enabled()) {
         LocationGuard immediate_guard{tokenizer};
-        WASP_TRY_READ(value_type_list, ReadResultList(tokenizer, context));
+        WASP_TRY_READ(value_type_list, ReadResultList(tokenizer, ctx));
         immediate = At{immediate_guard.loc(), value_type_list};
         if (!value_type_list.empty()) {
           // Typed select has a different opcode.
@@ -1751,45 +1730,45 @@ auto ReadPlainInstruction(Tokenizer& tokenizer, Context& context)
     }
 
     case TokenType::SimdConstInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
-      WASP_TRY_READ(immediate, ReadSimdConst(tokenizer, context));
+      WASP_TRY_READ(immediate, ReadSimdConst(tokenizer, ctx));
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::SimdLaneInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
-      WASP_TRY_READ(immediate, ReadSimdLane(tokenizer, context));
+      WASP_TRY_READ(immediate, ReadSimdLane(tokenizer, ctx));
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::SimdShuffleInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
-      WASP_TRY_READ(immediate, ReadSimdShuffleImmediate(tokenizer, context));
+      WASP_TRY_READ(immediate, ReadSimdShuffleImmediate(tokenizer, ctx));
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::StructFieldInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       LocationGuard immediate_guard{tokenizer};
-      WASP_TRY_READ(struct_var, ReadVar(tokenizer, context));
-      WASP_TRY_READ(field_var, ReadVar(tokenizer, context));
+      WASP_TRY_READ(struct_var, ReadVar(tokenizer, ctx));
+      WASP_TRY_READ(field_var, ReadVar(tokenizer, ctx));
       auto immediate = At{immediate_guard.loc(),
                           StructFieldImmediate{struct_var, field_var}};
       return At{guard.loc(), Instruction{token.opcode(), immediate}};
     }
 
     case TokenType::TableCopyInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       LocationGuard immediate_guard{tokenizer};
       At<CopyImmediate> immediate;
-      if (context.features.reference_types_enabled()) {
-        auto dst_var = ReadVarOpt(tokenizer, context);
-        auto src_var = ReadVarOpt(tokenizer, context);
+      if (ctx.features.reference_types_enabled()) {
+        auto dst_var = ReadVarOpt(tokenizer, ctx);
+        auto src_var = ReadVarOpt(tokenizer, ctx);
         immediate = At{immediate_guard.loc(), CopyImmediate{dst_var, src_var}};
       } else {
         immediate = At{immediate_guard.loc(), CopyImmediate{}};
@@ -1798,11 +1777,11 @@ auto ReadPlainInstruction(Tokenizer& tokenizer, Context& context)
     }
 
     case TokenType::TableInitInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       LocationGuard immediate_guard{tokenizer};
-      WASP_TRY_READ(segment_var, ReadVar(tokenizer, context));
-      auto table_var_opt = ReadVarOpt(tokenizer, context);
+      WASP_TRY_READ(segment_var, ReadVar(tokenizer, ctx));
+      auto table_var_opt = ReadVarOpt(tokenizer, ctx);
       At<InitImmediate> immediate;
       if (table_var_opt) {
         // table.init $table $elem ; so vars need to be swapped.
@@ -1818,20 +1797,20 @@ auto ReadPlainInstruction(Tokenizer& tokenizer, Context& context)
 
     case TokenType::VarInstr:
     case TokenType::RefFuncInstr: {
-      WASP_TRY(CheckOpcodeEnabled(token, context));
+      WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
-      WASP_TRY_READ(var, ReadVar(tokenizer, context));
+      WASP_TRY_READ(var, ReadVar(tokenizer, ctx));
       return At{guard.loc(), Instruction{token.opcode(), var}};
     }
 
     default:
-      context.errors.OnError(
+      ctx.errors.OnError(
           token.loc, concat("Expected plain instruction, got ", token.type));
       return nullopt;
   }
 }
 
-auto ReadLabelOpt(Tokenizer& tokenizer, Context& context) -> OptAt<BindVar> {
+auto ReadLabelOpt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<BindVar> {
   auto token_opt = tokenizer.Match(TokenType::Id);
   if (!token_opt) {
     return nullopt;
@@ -1840,47 +1819,45 @@ auto ReadLabelOpt(Tokenizer& tokenizer, Context& context) -> OptAt<BindVar> {
   return At{token_opt->loc, BindVar{token_opt->as_string_view()}};
 }
 
-bool ReadEndLabelOpt(Tokenizer& tokenizer,
-                     Context& context,
-                     OptAt<BindVar> label) {
-  auto end_label = ReadBindVarOpt(tokenizer, context);
+bool ReadEndLabelOpt(Tokenizer& tokenizer, ReadCtx& ctx, OptAt<BindVar> label) {
+  auto end_label = ReadBindVarOpt(tokenizer, ctx);
   if (end_label) {
     if (!label) {
-      context.errors.OnError(end_label->loc(),
-                             concat("Unexpected label ", end_label));
+      ctx.errors.OnError(end_label->loc(),
+                         concat("Unexpected label ", end_label));
       return false;
     } else if (*label != *end_label) {
-      context.errors.OnError(end_label->loc(), concat("Expected label ", *label,
-                                                      ", got ", *end_label));
+      ctx.errors.OnError(end_label->loc(), concat("Expected label ", *label,
+                                                  ", got ", *end_label));
       return false;
     }
   }
   return true;
 }
 
-auto ReadBlockImmediate(Tokenizer& tokenizer, Context& context)
+auto ReadBlockImmediate(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<BlockImmediate> {
   LocationGuard guard{tokenizer};
-  auto label = ReadLabelOpt(tokenizer, context);
+  auto label = ReadLabelOpt(tokenizer, ctx);
 
   // Don't use ReadFunctionTypeUse, since that always marks the type signature
   // as being used, even if it is an inline signature.
-  auto type_use = ReadTypeUseOpt(tokenizer, context);
-  WASP_TRY_READ(type, ReadFunctionType(tokenizer, context));
+  auto type_use = ReadTypeUseOpt(tokenizer, ctx);
+  WASP_TRY_READ(type, ReadFunctionType(tokenizer, ctx));
   auto ftu = FunctionTypeUse{type_use, type};
   return At{guard.loc(), BlockImmediate{label, ftu}};
 }
 
-auto ReadLetImmediate(Tokenizer& tokenizer, Context& context)
+auto ReadLetImmediate(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<LetImmediate> {
   LocationGuard guard{tokenizer};
-  WASP_TRY_READ(block, ReadBlockImmediate(tokenizer, context));
-  WASP_TRY_READ(locals, ReadLocalList(tokenizer, context));
+  WASP_TRY_READ(block, ReadBlockImmediate(tokenizer, ctx));
+  WASP_TRY_READ(locals, ReadLocalList(tokenizer, ctx));
   return At{guard.loc(), LetImmediate{block, locals}};
 }
 
 bool ReadOpcodeOpt(Tokenizer& tokenizer,
-                   Context& context,
+                   ReadCtx& ctx,
                    InstructionList& instructions,
                    TokenType token_type) {
   auto token_opt = tokenizer.Match(token_type);
@@ -1892,48 +1869,47 @@ bool ReadOpcodeOpt(Tokenizer& tokenizer,
 }
 
 bool ExpectOpcode(Tokenizer& tokenizer,
-                  Context& context,
+                  ReadCtx& ctx,
                   InstructionList& instructions,
                   TokenType token_type) {
   auto token = tokenizer.Peek();
-  if (!ReadOpcodeOpt(tokenizer, context, instructions, token_type)) {
-    context.errors.OnError(
-        token.loc, concat("Expected ", token_type, ", got ", token.type));
+  if (!ReadOpcodeOpt(tokenizer, ctx, instructions, token_type)) {
+    ctx.errors.OnError(token.loc,
+                       concat("Expected ", token_type, ", got ", token.type));
     return false;
   }
   return true;
 }
 
 bool ReadBlockInstruction(Tokenizer& tokenizer,
-                          Context& context,
+                          ReadCtx& ctx,
                           InstructionList& instructions) {
   LocationGuard guard{tokenizer};
   auto token_opt = tokenizer.Match(TokenType::BlockInstr);
   // Shouldn't be called when the TokenType is not a BlockInstr.
   assert(token_opt.has_value());
 
-  WASP_TRY_READ(block, ReadBlockImmediate(tokenizer, context));
+  WASP_TRY_READ(block, ReadBlockImmediate(tokenizer, ctx));
   instructions.push_back(
       At{guard.loc(), Instruction{token_opt->opcode(), block}});
-  WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
+  WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
 
   switch (token_opt->opcode()) {
     case Opcode::If:
-      if (ReadOpcodeOpt(tokenizer, context, instructions, TokenType::Else)) {
-        WASP_TRY(ReadEndLabelOpt(tokenizer, context, block->label));
-        WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
+      if (ReadOpcodeOpt(tokenizer, ctx, instructions, TokenType::Else)) {
+        WASP_TRY(ReadEndLabelOpt(tokenizer, ctx, block->label));
+        WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
       }
       break;
 
     case Opcode::Try:
-      if (!context.features.exceptions_enabled()) {
-        context.errors.OnError(token_opt->loc, "try instruction not allowed");
+      if (!ctx.features.exceptions_enabled()) {
+        ctx.errors.OnError(token_opt->loc, "try instruction not allowed");
         return false;
       }
-      WASP_TRY(
-          ExpectOpcode(tokenizer, context, instructions, TokenType::Catch));
-      WASP_TRY(ReadEndLabelOpt(tokenizer, context, block->label));
-      WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
+      WASP_TRY(ExpectOpcode(tokenizer, ctx, instructions, TokenType::Catch));
+      WASP_TRY(ReadEndLabelOpt(tokenizer, ctx, block->label));
+      WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
       break;
 
     case Opcode::Block:
@@ -1944,154 +1920,152 @@ bool ReadBlockInstruction(Tokenizer& tokenizer,
       WASP_UNREACHABLE();
   }
 
-  WASP_TRY(ExpectOpcode(tokenizer, context, instructions, TokenType::End));
-  WASP_TRY(ReadEndLabelOpt(tokenizer, context, block->label));
+  WASP_TRY(ExpectOpcode(tokenizer, ctx, instructions, TokenType::End));
+  WASP_TRY(ReadEndLabelOpt(tokenizer, ctx, block->label));
   return true;
 }
 
 bool ReadLetInstruction(Tokenizer& tokenizer,
-                        Context& context,
+                        ReadCtx& ctx,
                         InstructionList& instructions) {
   LocationGuard guard{tokenizer};
   auto token_opt = tokenizer.Match(TokenType::LetInstr);
   // Shouldn't be called when the TokenType is not a LetInstr.
   assert(token_opt.has_value());
 
-  WASP_TRY_READ(immediate, ReadLetImmediate(tokenizer, context));
+  WASP_TRY_READ(immediate, ReadLetImmediate(tokenizer, ctx));
   instructions.push_back(
       At{guard.loc(), Instruction{token_opt->opcode(), immediate}});
-  WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
-  WASP_TRY(ExpectOpcode(tokenizer, context, instructions, TokenType::End));
-  WASP_TRY(ReadEndLabelOpt(tokenizer, context, immediate->block.label));
+  WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
+  WASP_TRY(ExpectOpcode(tokenizer, ctx, instructions, TokenType::End));
+  WASP_TRY(ReadEndLabelOpt(tokenizer, ctx, immediate->block.label));
   return true;
 }
 
 bool ReadInstruction(Tokenizer& tokenizer,
-                     Context& context,
+                     ReadCtx& ctx,
                      InstructionList& instructions) {
   auto token = tokenizer.Peek();
   if (IsPlainInstruction(token)) {
-    WASP_TRY_READ(instruction, ReadPlainInstruction(tokenizer, context));
+    WASP_TRY_READ(instruction, ReadPlainInstruction(tokenizer, ctx));
     instructions.push_back(instruction);
   } else if (IsBlockInstruction(token)) {
-    WASP_TRY(ReadBlockInstruction(tokenizer, context, instructions));
+    WASP_TRY(ReadBlockInstruction(tokenizer, ctx, instructions));
   } else if (IsLetInstruction(token)) {
-    WASP_TRY(ReadLetInstruction(tokenizer, context, instructions));
+    WASP_TRY(ReadLetInstruction(tokenizer, ctx, instructions));
   } else if (IsExpression(tokenizer)) {
-    WASP_TRY(ReadExpression(tokenizer, context, instructions));
+    WASP_TRY(ReadExpression(tokenizer, ctx, instructions));
   } else {
-    context.errors.OnError(token.loc,
-                           concat("Expected instruction, got ", token.type));
+    ctx.errors.OnError(token.loc,
+                       concat("Expected instruction, got ", token.type));
     return false;
   }
   return true;
 }
 
 bool ReadInstructionList(Tokenizer& tokenizer,
-                         Context& context,
+                         ReadCtx& ctx,
                          InstructionList& instructions) {
   while (IsInstruction(tokenizer)) {
-    WASP_TRY(ReadInstruction(tokenizer, context, instructions));
+    WASP_TRY(ReadInstruction(tokenizer, ctx, instructions));
   }
   return true;
 }
 
 bool ReadRparAsEndInstruction(Tokenizer& tokenizer,
-                              Context& context,
+                              ReadCtx& ctx,
                               InstructionList& instructions) {
   // Read final `)` and use its location as the `end` instruction.
   auto rpar = tokenizer.Peek();
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   instructions.push_back(At{rpar.loc, Instruction{At{rpar.loc, Opcode::End}}});
   return true;
 }
 
 bool ReadExpression(Tokenizer& tokenizer,
-                    Context& context,
+                    ReadCtx& ctx,
                     InstructionList& instructions) {
-  WASP_TRY(Expect(tokenizer, context, TokenType::Lpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Lpar));
 
   auto token = tokenizer.Peek();
 
   if (IsPlainInstruction(token)) {
-    WASP_TRY_READ(plain, ReadPlainInstruction(tokenizer, context));
+    WASP_TRY_READ(plain, ReadPlainInstruction(tokenizer, ctx));
     // Reorder the instructions, so `(A (B) (C))` becomes `(B) (C) (A)`.
-    WASP_TRY(ReadExpressionList(tokenizer, context, instructions));
+    WASP_TRY(ReadExpressionList(tokenizer, ctx, instructions));
     instructions.push_back(plain);
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   } else if (IsBlockInstruction(token)) {
     LocationGuard guard{tokenizer};
     tokenizer.Read();
-    WASP_TRY_READ(block, ReadBlockImmediate(tokenizer, context));
+    WASP_TRY_READ(block, ReadBlockImmediate(tokenizer, ctx));
     auto block_instr = At{guard.loc(), Instruction{token.opcode(), block}};
 
     switch (token.opcode()) {
       case Opcode::Block:
       case Opcode::Loop:
         instructions.push_back(block_instr);
-        WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
+        WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
         break;
 
       case Opcode::If:
         // Read condition, if any. It doesn't need to exist, since the folded
         // `if` syntax is extremely flexible.
-        WASP_TRY(ReadExpressionList(tokenizer, context, instructions));
+        WASP_TRY(ReadExpressionList(tokenizer, ctx, instructions));
 
         // The `if` instruction must come after the condition.
         instructions.push_back(block_instr);
 
         // Read then block.
-        WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Then));
-        WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
-        WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+        WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Then));
+        WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
+        WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
 
         // Read else block, if any.
         if (tokenizer.Match(TokenType::Lpar)) {
-          WASP_TRY(
-              ExpectOpcode(tokenizer, context, instructions, TokenType::Else));
-          WASP_TRY(ReadEndLabelOpt(tokenizer, context, block->label));
-          WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
-          WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+          WASP_TRY(ExpectOpcode(tokenizer, ctx, instructions, TokenType::Else));
+          WASP_TRY(ReadEndLabelOpt(tokenizer, ctx, block->label));
+          WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
+          WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
         }
         break;
 
       case Opcode::Try:
-        if (!context.features.exceptions_enabled()) {
-          context.errors.OnError(token.loc, "try instruction not allowed");
+        if (!ctx.features.exceptions_enabled()) {
+          ctx.errors.OnError(token.loc, "try instruction not allowed");
           return false;
         }
         instructions.push_back(block_instr);
-        WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
+        WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
 
         // Read catch block.
-        WASP_TRY(Expect(tokenizer, context, TokenType::Lpar));
-        WASP_TRY(
-            ExpectOpcode(tokenizer, context, instructions, TokenType::Catch));
-        WASP_TRY(ReadEndLabelOpt(tokenizer, context, block->label));
-        WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
-        WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+        WASP_TRY(Expect(tokenizer, ctx, TokenType::Lpar));
+        WASP_TRY(ExpectOpcode(tokenizer, ctx, instructions, TokenType::Catch));
+        WASP_TRY(ReadEndLabelOpt(tokenizer, ctx, block->label));
+        WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
+        WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
         break;
 
       default:
         WASP_UNREACHABLE();
     }
 
-    WASP_TRY(ReadRparAsEndInstruction(tokenizer, context, instructions));
+    WASP_TRY(ReadRparAsEndInstruction(tokenizer, ctx, instructions));
   } else if (IsLetInstruction(token)) {
     LocationGuard guard{tokenizer};
     tokenizer.Read();
-    if (!context.features.function_references_enabled()) {
-      context.errors.OnError(token.loc, "let instruction not allowed");
+    if (!ctx.features.function_references_enabled()) {
+      ctx.errors.OnError(token.loc, "let instruction not allowed");
       return false;
     }
 
-    WASP_TRY_READ(immediate, ReadLetImmediate(tokenizer, context));
+    WASP_TRY_READ(immediate, ReadLetImmediate(tokenizer, ctx));
     instructions.push_back(
         At{guard.loc(), Instruction{token.opcode(), immediate}});
-    WASP_TRY(ReadInstructionList(tokenizer, context, instructions));
-    WASP_TRY(ReadRparAsEndInstruction(tokenizer, context, instructions));
+    WASP_TRY(ReadInstructionList(tokenizer, ctx, instructions));
+    WASP_TRY(ReadRparAsEndInstruction(tokenizer, ctx, instructions));
   } else {
-    context.errors.OnError(token.loc,
+    ctx.errors.OnError(token.loc,
                            concat("Expected expression, got ", token.type));
     return false;
   }
@@ -2099,38 +2073,37 @@ bool ReadExpression(Tokenizer& tokenizer,
 }
 
 bool ReadExpressionList(Tokenizer& tokenizer,
-                        Context& context,
+                        ReadCtx& ctx,
                         InstructionList& instructions) {
   while (IsExpression(tokenizer)) {
-    WASP_TRY(ReadExpression(tokenizer, context, instructions));
+    WASP_TRY(ReadExpression(tokenizer, ctx, instructions));
   }
   return true;
 }
 
 // Section 11: Data
 
-auto ReadMemoryUseOpt(Tokenizer& tokenizer, Context& context) -> OptAt<Var> {
-  return ReadVarUseOpt(tokenizer, context, TokenType::Memory);
+auto ReadMemoryUseOpt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Var> {
+  return ReadVarUseOpt(tokenizer, ctx, TokenType::Memory);
 }
 
-auto ReadDataSegment(Tokenizer& tokenizer, Context& context)
-    -> OptAt<DataSegment> {
+auto ReadDataSegment(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<DataSegment> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Data));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Data));
 
-  if (context.features.bulk_memory_enabled()) {
+  if (ctx.features.bulk_memory_enabled()) {
     // LPAR DATA * bind_var_opt string_list RPAR
     // LPAR DATA * bind_var_opt memory_use offset string_list RPAR
     // LPAR DATA * bind_var_opt offset string_list RPAR  /* Sugar */
-    auto name = ReadBindVarOpt(tokenizer, context);
-    auto memory_use_opt = ReadMemoryUseOpt(tokenizer, context);
+    auto name = ReadBindVarOpt(tokenizer, ctx);
+    auto memory_use_opt = ReadMemoryUseOpt(tokenizer, ctx);
 
     SegmentType segment_type;
     OptAt<ConstantExpression> offset_opt;
     if (memory_use_opt || tokenizer.Peek().type == TokenType::Lpar) {
       // LPAR DATA bind_var_opt memory_use * offset string_list RPAR
       // LPAR DATA bind_var_opt * offset string_list RPAR  /* Sugar */
-      WASP_TRY_READ(offset, ReadOffsetExpression(tokenizer, context));
+      WASP_TRY_READ(offset, ReadOffsetExpression(tokenizer, ctx));
       offset_opt = offset;
       segment_type = SegmentType::Active;
     } else {
@@ -2138,8 +2111,8 @@ auto ReadDataSegment(Tokenizer& tokenizer, Context& context)
       segment_type = SegmentType::Passive;
     }
     // ... * string_list RPAR
-    WASP_TRY_READ(data, ReadDataItemList(tokenizer, context));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY_READ(data, ReadDataItemList(tokenizer, ctx));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
 
     if (segment_type == SegmentType::Active) {
       assert(offset_opt.has_value());
@@ -2151,40 +2124,40 @@ auto ReadDataSegment(Tokenizer& tokenizer, Context& context)
   } else {
     // LPAR DATA var offset string_list RPAR
     // LPAR DATA offset string_list RPAR  /* Sugar */
-    auto memory = ReadVarOpt(tokenizer, context);
-    WASP_TRY_READ(offset, ReadOffsetExpression(tokenizer, context));
-    WASP_TRY_READ(data, ReadDataItemList(tokenizer, context));
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    auto memory = ReadVarOpt(tokenizer, ctx);
+    WASP_TRY_READ(offset, ReadOffsetExpression(tokenizer, ctx));
+    WASP_TRY_READ(data, ReadDataItemList(tokenizer, ctx));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
     return At{guard.loc(), DataSegment{nullopt, memory, offset, data}};
   }
 }
 
 // Section 13: Event
 
-auto ReadEventType(Tokenizer& tokenizer, Context& context) -> OptAt<EventType> {
+auto ReadEventType(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<EventType> {
   LocationGuard guard{tokenizer};
   auto attribute = EventAttribute::Exception;
-  WASP_TRY_READ(type, ReadFunctionTypeUse(tokenizer, context));
+  WASP_TRY_READ(type, ReadFunctionTypeUse(tokenizer, ctx));
   return At{guard.loc(), EventType{attribute, type}};
 }
 
-auto ReadEvent(Tokenizer& tokenizer, Context& context) -> OptAt<Event> {
+auto ReadEvent(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Event> {
   LocationGuard guard{tokenizer};
   auto token = tokenizer.Peek();
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Event));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Event));
 
-  if (!context.features.exceptions_enabled()) {
-    context.errors.OnError(token.loc, "Events not allowed");
+  if (!ctx.features.exceptions_enabled()) {
+    ctx.errors.OnError(token.loc, "Events not allowed");
     return nullopt;
   }
 
-  auto name = ReadBindVarOpt(tokenizer, context);
-  WASP_TRY_READ(exports, ReadInlineExportList(tokenizer, context));
-  auto import_opt = ReadInlineImportOpt(tokenizer, context);
-  context.seen_non_import |= !import_opt;
+  auto name = ReadBindVarOpt(tokenizer, ctx);
+  WASP_TRY_READ(exports, ReadInlineExportList(tokenizer, ctx));
+  auto import_opt = ReadInlineImportOpt(tokenizer, ctx);
+  ctx.seen_non_import |= !import_opt;
 
-  WASP_TRY_READ(type, ReadEventType(tokenizer, context));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY_READ(type, ReadEventType(tokenizer, ctx));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), Event{EventDesc{name, type}, import_opt, exports}};
 }
 
@@ -2204,73 +2177,72 @@ bool IsModuleItem(Tokenizer& tokenizer) {
          token.type == TokenType::Event;
 }
 
-auto ReadModuleItem(Tokenizer& tokenizer, Context& context)
-    -> OptAt<ModuleItem> {
+auto ReadModuleItem(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<ModuleItem> {
   auto token = tokenizer.Peek();
   if (token.type != TokenType::Lpar) {
-    context.errors.OnError(token.loc, concat("Expected '(', got ", token.type));
+    ctx.errors.OnError(token.loc, concat("Expected '(', got ", token.type));
     return nullopt;
   }
 
   token = tokenizer.Peek(1);
   switch (token.type) {
     case TokenType::Type: {
-      WASP_TRY_READ(item, ReadDefinedType(tokenizer, context));
+      WASP_TRY_READ(item, ReadDefinedType(tokenizer, ctx));
       return At{item.loc(), ModuleItem{*item}};
     }
 
     case TokenType::Import: {
-      WASP_TRY_READ(item, ReadImport(tokenizer, context));
+      WASP_TRY_READ(item, ReadImport(tokenizer, ctx));
       return At{item.loc(), ModuleItem{*item}};
     }
 
     case TokenType::Func: {
-      WASP_TRY_READ(item, ReadFunction(tokenizer, context));
+      WASP_TRY_READ(item, ReadFunction(tokenizer, ctx));
       return At{item.loc(), ModuleItem{*item}};
     }
 
     case TokenType::Table: {
-      WASP_TRY_READ(item, ReadTable(tokenizer, context));
+      WASP_TRY_READ(item, ReadTable(tokenizer, ctx));
       return At{item.loc(), ModuleItem{*item}};
     }
 
     case TokenType::Memory: {
-      WASP_TRY_READ(item, ReadMemory(tokenizer, context));
+      WASP_TRY_READ(item, ReadMemory(tokenizer, ctx));
       return At{item.loc(), ModuleItem{*item}};
     }
 
     case TokenType::Global: {
-      WASP_TRY_READ(item, ReadGlobal(tokenizer, context));
+      WASP_TRY_READ(item, ReadGlobal(tokenizer, ctx));
       return At{item.loc(), ModuleItem{*item}};
     }
 
     case TokenType::Export: {
-      WASP_TRY_READ(item, ReadExport(tokenizer, context));
+      WASP_TRY_READ(item, ReadExport(tokenizer, ctx));
       return At{item.loc(), ModuleItem{*item}};
     }
 
     case TokenType::Start: {
-      WASP_TRY_READ(item, ReadStart(tokenizer, context));
+      WASP_TRY_READ(item, ReadStart(tokenizer, ctx));
       return At{item.loc(), ModuleItem{*item}};
     }
 
     case TokenType::Elem: {
-      WASP_TRY_READ(item, ReadElementSegment(tokenizer, context));
+      WASP_TRY_READ(item, ReadElementSegment(tokenizer, ctx));
       return At{item.loc(), ModuleItem{*item}};
     }
 
     case TokenType::Data: {
-      WASP_TRY_READ(item, ReadDataSegment(tokenizer, context));
+      WASP_TRY_READ(item, ReadDataSegment(tokenizer, ctx));
       return At{item.loc(), ModuleItem{*item}};
     }
 
     case TokenType::Event: {
-      WASP_TRY_READ(item, ReadEvent(tokenizer, context));
+      WASP_TRY_READ(item, ReadEvent(tokenizer, ctx));
       return At{item.loc(), ModuleItem{*item}};
     }
 
     default:
-      context.errors.OnError(
+      ctx.errors.OnError(
           token.loc,
           concat(
               "Expected 'type', 'import', 'func', 'table', 'memory', 'global', "
@@ -2280,54 +2252,53 @@ auto ReadModuleItem(Tokenizer& tokenizer, Context& context)
   }
 }
 
-auto ReadModule(Tokenizer& tokenizer, Context& context) -> optional<Module> {
-  context.BeginModule();
+auto ReadModule(Tokenizer& tokenizer, ReadCtx& ctx) -> optional<Module> {
+  ctx.BeginModule();
   Module module;
   while (IsModuleItem(tokenizer)) {
-    WASP_TRY_READ(item, ReadModuleItem(tokenizer, context));
+    WASP_TRY_READ(item, ReadModuleItem(tokenizer, ctx));
     module.push_back(item);
   }
   return module;
 }
 
-auto ReadSingleModule(Tokenizer& tokenizer, Context& context)
-    -> optional<Module> {
+auto ReadSingleModule(Tokenizer& tokenizer, ReadCtx& ctx) -> optional<Module> {
   // Check whether it's wrapped in (module... )
   bool in_module = false;
   if (tokenizer.MatchLpar(TokenType::Module).has_value()) {
     in_module = true;
     // Read optional module name, but discard it.
-    ReadModuleVarOpt(tokenizer, context);
+    ReadModuleVarOpt(tokenizer, ctx);
   }
 
-  auto module = ReadModule(tokenizer, context);
+  auto module = ReadModule(tokenizer, ctx);
 
   if (in_module) {
-    WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+    WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   }
   return module;
 }
 
 // Explicit instantiations.
-template auto ReadInt<s8>(Tokenizer&, Context&) -> OptAt<s8>;
-template auto ReadInt<u8>(Tokenizer&, Context&) -> OptAt<u8>;
-template auto ReadInt<s16>(Tokenizer&, Context&) -> OptAt<s16>;
-template auto ReadInt<u16>(Tokenizer&, Context&) -> OptAt<u16>;
-template auto ReadInt<s32>(Tokenizer&, Context&) -> OptAt<s32>;
-template auto ReadInt<u32>(Tokenizer&, Context&) -> OptAt<u32>;
-template auto ReadInt<s64>(Tokenizer&, Context&) -> OptAt<s64>;
-template auto ReadInt<u64>(Tokenizer&, Context&) -> OptAt<u64>;
-template auto ReadFloat<f32>(Tokenizer&, Context&) -> OptAt<f32>;
-template auto ReadFloat<f64>(Tokenizer&, Context&) -> OptAt<f64>;
-template auto ReadSimdValues<s8, 16>(Tokenizer&, Context&) -> OptAt<v128>;
-template auto ReadSimdValues<u8, 16>(Tokenizer&, Context&) -> OptAt<v128>;
-template auto ReadSimdValues<s16, 8>(Tokenizer&, Context&) -> OptAt<v128>;
-template auto ReadSimdValues<u16, 8>(Tokenizer&, Context&) -> OptAt<v128>;
-template auto ReadSimdValues<s32, 4>(Tokenizer&, Context&) -> OptAt<v128>;
-template auto ReadSimdValues<u32, 4>(Tokenizer&, Context&) -> OptAt<v128>;
-template auto ReadSimdValues<s64, 2>(Tokenizer&, Context&) -> OptAt<v128>;
-template auto ReadSimdValues<u64, 2>(Tokenizer&, Context&) -> OptAt<v128>;
-template auto ReadSimdValues<f32, 4>(Tokenizer&, Context&) -> OptAt<v128>;
-template auto ReadSimdValues<f64, 2>(Tokenizer&, Context&) -> OptAt<v128>;
+template auto ReadInt<s8>(Tokenizer&, ReadCtx&) -> OptAt<s8>;
+template auto ReadInt<u8>(Tokenizer&, ReadCtx&) -> OptAt<u8>;
+template auto ReadInt<s16>(Tokenizer&, ReadCtx&) -> OptAt<s16>;
+template auto ReadInt<u16>(Tokenizer&, ReadCtx&) -> OptAt<u16>;
+template auto ReadInt<s32>(Tokenizer&, ReadCtx&) -> OptAt<s32>;
+template auto ReadInt<u32>(Tokenizer&, ReadCtx&) -> OptAt<u32>;
+template auto ReadInt<s64>(Tokenizer&, ReadCtx&) -> OptAt<s64>;
+template auto ReadInt<u64>(Tokenizer&, ReadCtx&) -> OptAt<u64>;
+template auto ReadFloat<f32>(Tokenizer&, ReadCtx&) -> OptAt<f32>;
+template auto ReadFloat<f64>(Tokenizer&, ReadCtx&) -> OptAt<f64>;
+template auto ReadSimdValues<s8, 16>(Tokenizer&, ReadCtx&) -> OptAt<v128>;
+template auto ReadSimdValues<u8, 16>(Tokenizer&, ReadCtx&) -> OptAt<v128>;
+template auto ReadSimdValues<s16, 8>(Tokenizer&, ReadCtx&) -> OptAt<v128>;
+template auto ReadSimdValues<u16, 8>(Tokenizer&, ReadCtx&) -> OptAt<v128>;
+template auto ReadSimdValues<s32, 4>(Tokenizer&, ReadCtx&) -> OptAt<v128>;
+template auto ReadSimdValues<u32, 4>(Tokenizer&, ReadCtx&) -> OptAt<v128>;
+template auto ReadSimdValues<s64, 2>(Tokenizer&, ReadCtx&) -> OptAt<v128>;
+template auto ReadSimdValues<u64, 2>(Tokenizer&, ReadCtx&) -> OptAt<v128>;
+template auto ReadSimdValues<f32, 4>(Tokenizer&, ReadCtx&) -> OptAt<v128>;
+template auto ReadSimdValues<f64, 2>(Tokenizer&, ReadCtx&) -> OptAt<v128>;
 
 }  // namespace wasp::text

--- a/src/text/read_ctx.cc
+++ b/src/text/read_ctx.cc
@@ -14,31 +14,18 @@
 // limitations under the License.
 //
 
-#ifndef WASP_TEXT_READ_CONTEXT_H_
-#define WASP_TEXT_READ_CONTEXT_H_
+#include "wasp/text/read/read_ctx.h"
 
-#include "wasp/base/features.h"
+namespace wasp::text {
 
-namespace wasp {
+ReadCtx::ReadCtx(Errors& errors) : errors{errors} {}
 
-class Errors;
+ReadCtx::ReadCtx(const Features& features, Errors& errors)
+    : features{features}, errors{errors} {}
 
-namespace text {
+void ReadCtx::BeginModule() {
+  seen_non_import = false;
+  seen_start = false;
+}
 
-struct Context {
-  explicit Context(Errors&);
-  explicit Context(const Features&, Errors&);
-
-  void BeginModule();    // Reset all module-specific context.
-
-  Features features;
-  Errors& errors;
-
-  bool seen_non_import = false;
-  bool seen_start = false;
-};
-
-}  // namespace text
-}  // namespace wasp
-
-#endif  // WASP_TEXT_READ_CONTEXT_H_
+}  // namespace wasp::text

--- a/src/text/read_script.cc
+++ b/src/text/read_script.cc
@@ -21,15 +21,14 @@
 #include "wasp/base/concat.h"
 #include "wasp/base/errors.h"
 #include "wasp/text/formatters.h"
-#include "wasp/text/read/context.h"
 #include "wasp/text/read/location_guard.h"
 #include "wasp/text/read/macros.h"
+#include "wasp/text/read/read_ctx.h"
 #include "wasp/text/resolve.h"
 
 namespace wasp::text {
 
-auto ReadModuleVarOpt(Tokenizer& tokenizer, Context& context)
-    -> OptAt<ModuleVar> {
+auto ReadModuleVarOpt(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<ModuleVar> {
   auto token_opt = tokenizer.Match(TokenType::Id);
   if (!token_opt) {
     return nullopt;
@@ -37,32 +36,32 @@ auto ReadModuleVarOpt(Tokenizer& tokenizer, Context& context)
   return At{token_opt->loc, ModuleVar{token_opt->as_string_view()}};
 }
 
-auto ReadScriptModule(Tokenizer& tokenizer, Context& context)
+auto ReadScriptModule(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<ScriptModule> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Module));
-  auto name_opt = ReadModuleVarOpt(tokenizer, context);
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Module));
+  auto name_opt = ReadModuleVarOpt(tokenizer, ctx);
   auto token = tokenizer.Peek();
   switch (token.type) {
     case TokenType::Binary: {
       tokenizer.Read();
-      WASP_TRY_READ(text_list, ReadTextList(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(text_list, ReadTextList(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(),
                 ScriptModule{name_opt, ScriptModuleKind::Binary, text_list}};
     }
 
     case TokenType::Quote: {
       tokenizer.Read();
-      WASP_TRY_READ(text_list, ReadTextList(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(text_list, ReadTextList(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(),
                 ScriptModule{name_opt, ScriptModuleKind::Quote, text_list}};
     }
 
     default: {
-      WASP_TRY_READ(module, ReadModule(tokenizer, context));
-      Expect(tokenizer, context, TokenType::Rpar);
+      WASP_TRY_READ(module, ReadModule(tokenizer, ctx));
+      Expect(tokenizer, ctx, TokenType::Rpar);
       return At{guard.loc(),
                 ScriptModule{name_opt, ScriptModuleKind::Text, module}};
     }
@@ -84,155 +83,154 @@ bool IsConst(Tokenizer& tokenizer) {
          token.type == TokenType::RefExtern;
 }
 
-auto ReadConst(Tokenizer& tokenizer, Context& context) -> OptAt<Const> {
+auto ReadConst(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Const> {
   // TODO: Share with ReadPlainInstruction above?
   LocationGuard guard{tokenizer};
-  WASP_TRY(Expect(tokenizer, context, TokenType::Lpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Lpar));
 
   auto token = tokenizer.Peek();
   switch (token.type) {
     case TokenType::F32ConstInstr: {
       tokenizer.Read();
-      WASP_TRY_READ(literal, ReadFloat<f32>(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(literal, ReadFloat<f32>(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Const{literal.value()}};
     }
 
     case TokenType::F64ConstInstr: {
       tokenizer.Read();
-      WASP_TRY_READ(literal, ReadFloat<f64>(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(literal, ReadFloat<f64>(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Const{literal.value()}};
     }
 
     case TokenType::I32ConstInstr: {
       tokenizer.Read();
-      WASP_TRY_READ(literal, ReadInt<u32>(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(literal, ReadInt<u32>(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Const{literal.value()}};
     }
 
     case TokenType::I64ConstInstr: {
       tokenizer.Read();
-      WASP_TRY_READ(literal, ReadInt<u64>(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(literal, ReadInt<u64>(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Const{literal.value()}};
     }
 
     case TokenType::SimdConstInstr: {
-      if (!context.features.simd_enabled()) {
-        context.errors.OnError(token.loc, "Simd values not allowed");
+      if (!ctx.features.simd_enabled()) {
+        ctx.errors.OnError(token.loc, "Simd values not allowed");
         return nullopt;
       }
       tokenizer.Read();
-      WASP_TRY_READ(literal, ReadSimdConst(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(literal, ReadSimdConst(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Const{literal.value()}};
     }
 
     case TokenType::RefNullInstr: {
-      if (!context.features.reference_types_enabled()) {
-        context.errors.OnError(token.loc, "ref.null not allowed");
+      if (!ctx.features.reference_types_enabled()) {
+        ctx.errors.OnError(token.loc, "ref.null not allowed");
         return nullopt;
       }
       tokenizer.Read();
-      WASP_TRY_READ(type, ReadHeapType(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(type, ReadHeapType(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Const{RefNullConst{type}}};
     }
 
     case TokenType::RefExtern: {
-      if (!context.features.reference_types_enabled()) {
-        context.errors.OnError(token.loc, "ref.extern not allowed");
+      if (!ctx.features.reference_types_enabled()) {
+        ctx.errors.OnError(token.loc, "ref.extern not allowed");
         return nullopt;
       }
       tokenizer.Read();
-      WASP_TRY_READ(nat, ReadNat32(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(nat, ReadNat32(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Const{RefExternConst{nat}}};
     }
 
     default:
-      context.errors.OnError(token.loc,
-                             concat("Invalid constant, got ", token.type));
+      ctx.errors.OnError(token.loc,
+                         concat("Invalid constant, got ", token.type));
       return nullopt;
   }
 }
 
-auto ReadConstList(Tokenizer& tokenizer, Context& context)
-    -> optional<ConstList> {
+auto ReadConstList(Tokenizer& tokenizer, ReadCtx& ctx) -> optional<ConstList> {
   ConstList result;
   while (IsConst(tokenizer)) {
-    WASP_TRY_READ(const_, ReadConst(tokenizer, context));
+    WASP_TRY_READ(const_, ReadConst(tokenizer, ctx));
     result.push_back(const_);
   }
   return result;
 }
 
-auto ReadInvokeAction(Tokenizer& tokenizer, Context& context)
+auto ReadInvokeAction(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<InvokeAction> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Invoke));
-  auto module_opt = ReadModuleVarOpt(tokenizer, context);
-  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, context));
-  WASP_TRY_READ(const_list, ReadConstList(tokenizer, context));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Invoke));
+  auto module_opt = ReadModuleVarOpt(tokenizer, ctx);
+  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, ctx));
+  WASP_TRY_READ(const_list, ReadConstList(tokenizer, ctx));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), InvokeAction{module_opt, name, const_list}};
 }
 
-auto ReadGetAction(Tokenizer& tokenizer, Context& context) -> OptAt<GetAction> {
+auto ReadGetAction(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<GetAction> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Get));
-  auto module_opt = ReadModuleVarOpt(tokenizer, context);
-  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, context));
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Get));
+  auto module_opt = ReadModuleVarOpt(tokenizer, ctx);
+  WASP_TRY_READ(name, ReadUtf8Text(tokenizer, ctx));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), GetAction{module_opt, name}};
 }
 
-auto ReadAction(Tokenizer& tokenizer, Context& context) -> OptAt<Action> {
+auto ReadAction(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Action> {
   auto token = tokenizer.Peek();
   if (token.type != TokenType::Lpar) {
-    context.errors.OnError(token.loc, concat("Expected '(', got ", token.type));
+    ctx.errors.OnError(token.loc, concat("Expected '(', got ", token.type));
     return nullopt;
   }
 
   token = tokenizer.Peek(1);
   switch (token.type) {
     case TokenType::Invoke: {
-      WASP_TRY_READ(action, ReadInvokeAction(tokenizer, context));
+      WASP_TRY_READ(action, ReadInvokeAction(tokenizer, ctx));
       return At{action.loc(), Action{action.value()}};
     }
 
     case TokenType::Get: {
-      WASP_TRY_READ(action, ReadGetAction(tokenizer, context));
+      WASP_TRY_READ(action, ReadGetAction(tokenizer, ctx));
       return At{action.loc(), Action{action.value()}};
     }
 
     default:
-      context.errors.OnError(token.loc,
-                             concat("Invalid action type, got ", token.type));
+      ctx.errors.OnError(token.loc,
+                         concat("Invalid action type, got ", token.type));
       return nullopt;
   }
 }
 
-auto ReadModuleAssertion(Tokenizer& tokenizer, Context& context)
+auto ReadModuleAssertion(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<ModuleAssertion> {
   LocationGuard guard{tokenizer};
-  WASP_TRY_READ(module, ReadScriptModule(tokenizer, context));
-  WASP_TRY_READ(text, ReadText(tokenizer, context));
+  WASP_TRY_READ(module, ReadScriptModule(tokenizer, ctx));
+  WASP_TRY_READ(text, ReadText(tokenizer, ctx));
   return At{guard.loc(), ModuleAssertion{module, text}};
 }
 
-auto ReadActionAssertion(Tokenizer& tokenizer, Context& context)
+auto ReadActionAssertion(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<ActionAssertion> {
   LocationGuard guard{tokenizer};
-  WASP_TRY_READ(action, ReadAction(tokenizer, context));
-  WASP_TRY_READ(text, ReadText(tokenizer, context));
+  WASP_TRY_READ(action, ReadAction(tokenizer, ctx));
+  WASP_TRY_READ(text, ReadText(tokenizer, ctx));
   return At{guard.loc(), ActionAssertion{action, text}};
 }
 
 template <typename T>
-auto ReadFloatResult(Tokenizer& tokenizer, Context& context)
+auto ReadFloatResult(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<FloatResult<T>> {
   auto token = tokenizer.Peek();
   switch (token.type) {
@@ -245,20 +243,20 @@ auto ReadFloatResult(Tokenizer& tokenizer, Context& context)
       return At{token.loc, FloatResult<T>{NanKind::Canonical}};
 
     default: {
-      WASP_TRY_READ(literal, (ReadFloat<T>(tokenizer, context)));
+      WASP_TRY_READ(literal, (ReadFloat<T>(tokenizer, ctx)));
       return At{literal.loc(), FloatResult<T>{literal.value()}};
     }
   }
 }
 
 template <typename T, size_t N>
-auto ReadSimdFloatResult(Tokenizer& tokenizer, Context& context)
+auto ReadSimdFloatResult(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<ReturnResult> {
   static_assert(std::is_floating_point_v<T>, "T must be floating point.");
   LocationGuard guard{tokenizer};
   std::array<FloatResult<T>, N> result;
   for (size_t lane = 0; lane < N; ++lane) {
-    WASP_TRY_READ(value, (ReadFloatResult<T>(tokenizer, context)));
+    WASP_TRY_READ(value, (ReadFloatResult<T>(tokenizer, ctx)));
     result[lane] = value;
   }
   return At{guard.loc(), ReturnResult{result}};
@@ -280,51 +278,51 @@ bool IsReturnResult(Tokenizer& tokenizer) {
          token.type == TokenType::RefFuncInstr;
 }
 
-auto ReadReturnResult(Tokenizer& tokenizer, Context& context)
+auto ReadReturnResult(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<ReturnResult> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(Expect(tokenizer, context, TokenType::Lpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Lpar));
 
   auto token = tokenizer.Peek();
   switch (token.type) {
     case TokenType::F32ConstInstr: {
       tokenizer.Read();
-      WASP_TRY_READ(result, (ReadFloatResult<f32>(tokenizer, context)));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(result, (ReadFloatResult<f32>(tokenizer, ctx)));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), ReturnResult{result.value()}};
     }
 
     case TokenType::F64ConstInstr: {
       tokenizer.Read();
-      WASP_TRY_READ(result, (ReadFloatResult<f64>(tokenizer, context)));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(result, (ReadFloatResult<f64>(tokenizer, ctx)));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), ReturnResult{result.value()}};
     }
 
     case TokenType::I32ConstInstr: {
       tokenizer.Read();
-      WASP_TRY_READ(result, (ReadInt<u32>(tokenizer, context)));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(result, (ReadInt<u32>(tokenizer, ctx)));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), ReturnResult{result.value()}};
     }
 
     case TokenType::I64ConstInstr: {
       tokenizer.Read();
-      WASP_TRY_READ(result, (ReadInt<u64>(tokenizer, context)));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(result, (ReadInt<u64>(tokenizer, ctx)));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), ReturnResult{result.value()}};
     }
 
     case TokenType::SimdConstInstr: {
-      if (!context.features.simd_enabled()) {
-        context.errors.OnError(token.loc, "Simd values not allowed");
+      if (!ctx.features.simd_enabled()) {
+        ctx.errors.OnError(token.loc, "Simd values not allowed");
         return nullopt;
       }
 
       tokenizer.Read();
       auto simd_token = tokenizer.Match(TokenType::SimdShape);
       if (!simd_token) {
-        context.errors.OnError(
+        ctx.errors.OnError(
             simd_token->loc,
             concat("Invalid SIMD constant token, got ", tokenizer.Peek().type));
         return nullopt;
@@ -333,39 +331,37 @@ auto ReadReturnResult(Tokenizer& tokenizer, Context& context)
       At<ReturnResult> result;
       switch (simd_token->simd_shape()) {
         case SimdShape::I8X16: {
-          WASP_TRY_READ(result_, (ReadSimdValues<u8, 16>(tokenizer, context)));
+          WASP_TRY_READ(result_, (ReadSimdValues<u8, 16>(tokenizer, ctx)));
           result = result_;
           break;
         }
 
         case SimdShape::I16X8: {
-          WASP_TRY_READ(result_, (ReadSimdValues<u16, 8>(tokenizer, context)));
+          WASP_TRY_READ(result_, (ReadSimdValues<u16, 8>(tokenizer, ctx)));
           result = result_;
           break;
         }
 
         case SimdShape::I32X4: {
-          WASP_TRY_READ(result_, (ReadSimdValues<u32, 4>(tokenizer, context)));
+          WASP_TRY_READ(result_, (ReadSimdValues<u32, 4>(tokenizer, ctx)));
           result = result_;
           break;
         }
 
         case SimdShape::I64X2: {
-          WASP_TRY_READ(result_, (ReadSimdValues<u64, 2>(tokenizer, context)));
+          WASP_TRY_READ(result_, (ReadSimdValues<u64, 2>(tokenizer, ctx)));
           result = result_;
           break;
         }
 
         case SimdShape::F32X4: {
-          WASP_TRY_READ(result_,
-                        (ReadSimdFloatResult<f32, 4>(tokenizer, context)));
+          WASP_TRY_READ(result_, (ReadSimdFloatResult<f32, 4>(tokenizer, ctx)));
           result = result_;
           break;
         }
 
         case SimdShape::F64X2: {
-          WASP_TRY_READ(result_,
-                        (ReadSimdFloatResult<f64, 2>(tokenizer, context)));
+          WASP_TRY_READ(result_, (ReadSimdFloatResult<f64, 2>(tokenizer, ctx)));
           result = result_;
           break;
         }
@@ -374,94 +370,93 @@ auto ReadReturnResult(Tokenizer& tokenizer, Context& context)
           WASP_UNREACHABLE();
       }
 
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), ReturnResult{result.value()}};
     }
 
     case TokenType::RefNullInstr: {
-      if (!context.features.reference_types_enabled()) {
-        context.errors.OnError(token.loc, "ref.null not allowed");
+      if (!ctx.features.reference_types_enabled()) {
+        ctx.errors.OnError(token.loc, "ref.null not allowed");
         return nullopt;
       }
       tokenizer.Read();
-      WASP_TRY_READ(type, ReadHeapType(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(type, ReadHeapType(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), ReturnResult{RefNullConst{type}}};
     }
 
     case TokenType::RefExtern:
-      if (!context.features.reference_types_enabled()) {
-        context.errors.OnError(token.loc, "ref.extern not allowed");
+      if (!ctx.features.reference_types_enabled()) {
+        ctx.errors.OnError(token.loc, "ref.extern not allowed");
         return nullopt;
       }
       tokenizer.Read();
       if (tokenizer.Peek().type == TokenType::Nat) {
-        WASP_TRY_READ(nat, ReadNat32(tokenizer, context));
-        WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+        WASP_TRY_READ(nat, ReadNat32(tokenizer, ctx));
+        WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
         return At{guard.loc(), ReturnResult{RefExternConst{nat}}};
       } else {
-        WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+        WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
         return At{guard.loc(), ReturnResult{RefExternResult{}}};
       }
 
     case TokenType::RefFuncInstr:
-      if (!context.features.reference_types_enabled()) {
-        context.errors.OnError(token.loc, "ref.func not allowed");
+      if (!ctx.features.reference_types_enabled()) {
+        ctx.errors.OnError(token.loc, "ref.func not allowed");
         return nullopt;
       }
       tokenizer.Read();
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), ReturnResult{RefFuncResult{}}};
 
     default:
-      context.errors.OnError(token.loc,
-                             concat("Invalid result, got ", token.type));
+      ctx.errors.OnError(token.loc, concat("Invalid result, got ", token.type));
       return nullopt;
   }
 }
 
-auto ReadReturnResultList(Tokenizer& tokenizer, Context& context)
+auto ReadReturnResultList(Tokenizer& tokenizer, ReadCtx& ctx)
     -> optional<ReturnResultList> {
   ReturnResultList result;
   while (IsReturnResult(tokenizer)) {
-    WASP_TRY_READ(value, ReadReturnResult(tokenizer, context));
+    WASP_TRY_READ(value, ReadReturnResult(tokenizer, ctx));
     result.push_back(value);
   }
   return result;
 }
 
-auto ReadReturnAssertion(Tokenizer& tokenizer, Context& context)
+auto ReadReturnAssertion(Tokenizer& tokenizer, ReadCtx& ctx)
     -> OptAt<ReturnAssertion> {
   LocationGuard guard{tokenizer};
-  WASP_TRY_READ(action, ReadAction(tokenizer, context));
-  WASP_TRY_READ(results, ReadReturnResultList(tokenizer, context));
+  WASP_TRY_READ(action, ReadAction(tokenizer, ctx));
+  WASP_TRY_READ(results, ReadReturnResultList(tokenizer, ctx));
   return At{guard.loc(), ReturnAssertion{action, results}};
 }
 
-auto ReadAssertion(Tokenizer& tokenizer, Context& context) -> OptAt<Assertion> {
+auto ReadAssertion(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Assertion> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(Expect(tokenizer, context, TokenType::Lpar));
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Lpar));
 
   auto token = tokenizer.Peek();
   switch (token.type) {
     case TokenType::AssertMalformed: {
       tokenizer.Read();
-      WASP_TRY_READ(module, ReadModuleAssertion(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(module, ReadModuleAssertion(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Assertion{AssertionKind::Malformed, module}};
     }
 
     case TokenType::AssertInvalid: {
       tokenizer.Read();
-      WASP_TRY_READ(module, ReadModuleAssertion(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(module, ReadModuleAssertion(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Assertion{AssertionKind::Invalid, module}};
     }
 
     case TokenType::AssertUnlinkable: {
       tokenizer.Read();
-      WASP_TRY_READ(module, ReadModuleAssertion(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(module, ReadModuleAssertion(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Assertion{AssertionKind::Unlinkable, module}};
     }
 
@@ -470,43 +465,43 @@ auto ReadAssertion(Tokenizer& tokenizer, Context& context) -> OptAt<Assertion> {
       // Don't bother checking for Lpar here; it will be checked in
       // ReadModuleAssertion or ReadActionAssertion below.
       if (tokenizer.Peek(1).type == TokenType::Module) {
-        WASP_TRY_READ(module, ReadModuleAssertion(tokenizer, context));
-        WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+        WASP_TRY_READ(module, ReadModuleAssertion(tokenizer, ctx));
+        WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
         return At{guard.loc(), Assertion{AssertionKind::ModuleTrap, module}};
       } else {
-        WASP_TRY_READ(action, ReadActionAssertion(tokenizer, context));
-        WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+        WASP_TRY_READ(action, ReadActionAssertion(tokenizer, ctx));
+        WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
         return At{guard.loc(), Assertion{AssertionKind::ActionTrap, action}};
       }
     }
 
     case TokenType::AssertReturn: {
       tokenizer.Read();
-      WASP_TRY_READ(action, ReadReturnAssertion(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(action, ReadReturnAssertion(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Assertion{AssertionKind::Return, action}};
     }
 
     case TokenType::AssertExhaustion: {
       tokenizer.Read();
-      WASP_TRY_READ(action, ReadActionAssertion(tokenizer, context));
-      WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+      WASP_TRY_READ(action, ReadActionAssertion(tokenizer, ctx));
+      WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
       return At{guard.loc(), Assertion{AssertionKind::Exhaustion, action}};
     }
 
     default:
-      context.errors.OnError(token.loc,
-                             concat("Invalid action type, got ", token.type));
+      ctx.errors.OnError(token.loc,
+                         concat("Invalid action type, got ", token.type));
       return nullopt;
   }
 }
 
-auto ReadRegister(Tokenizer& tokenizer, Context& context) -> OptAt<Register> {
+auto ReadRegister(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Register> {
   LocationGuard guard{tokenizer};
-  WASP_TRY(ExpectLpar(tokenizer, context, TokenType::Register));
-  WASP_TRY_READ(name, ReadText(tokenizer, context));
-  auto module_opt = ReadModuleVarOpt(tokenizer, context);
-  WASP_TRY(Expect(tokenizer, context, TokenType::Rpar));
+  WASP_TRY(ExpectLpar(tokenizer, ctx, TokenType::Register));
+  WASP_TRY_READ(name, ReadText(tokenizer, ctx));
+  auto module_opt = ReadModuleVarOpt(tokenizer, ctx);
+  WASP_TRY(Expect(tokenizer, ctx, TokenType::Rpar));
   return At{guard.loc(), Register{name, module_opt}};
 }
 
@@ -527,28 +522,28 @@ bool IsCommand(Tokenizer& tokenizer) {
          token.type == TokenType::AssertExhaustion;
 }
 
-auto ReadCommand(Tokenizer& tokenizer, Context& context) -> OptAt<Command> {
+auto ReadCommand(Tokenizer& tokenizer, ReadCtx& ctx) -> OptAt<Command> {
   auto token = tokenizer.Peek();
   if (token.type != TokenType::Lpar) {
-    context.errors.OnError(token.loc, concat("Expected '(', got ", token.type));
+    ctx.errors.OnError(token.loc, concat("Expected '(', got ", token.type));
     return nullopt;
   }
 
   token = tokenizer.Peek(1);
   switch (token.type) {
     case TokenType::Module: {
-      WASP_TRY_READ(item, ReadScriptModule(tokenizer, context));
+      WASP_TRY_READ(item, ReadScriptModule(tokenizer, ctx));
       return At{item.loc(), Command{item.value()}};
     }
 
     case TokenType::Invoke:
     case TokenType::Get: {
-      WASP_TRY_READ(item, ReadAction(tokenizer, context));
+      WASP_TRY_READ(item, ReadAction(tokenizer, ctx));
       return At{item.loc(), Command{item.value()}};
     }
 
     case TokenType::Register: {
-      WASP_TRY_READ(item, ReadRegister(tokenizer, context));
+      WASP_TRY_READ(item, ReadRegister(tokenizer, ctx));
       return At{item.loc(), Command{item.value()}};
     }
 
@@ -558,7 +553,7 @@ auto ReadCommand(Tokenizer& tokenizer, Context& context) -> OptAt<Command> {
     case TokenType::AssertTrap:
     case TokenType::AssertReturn:
     case TokenType::AssertExhaustion: {
-      WASP_TRY_READ(item, ReadAssertion(tokenizer, context));
+      WASP_TRY_READ(item, ReadAssertion(tokenizer, ctx));
       return At{item.loc(), Command{item.value()}};
     }
 
@@ -567,33 +562,32 @@ auto ReadCommand(Tokenizer& tokenizer, Context& context) -> OptAt<Command> {
         // Read an inline module (one without a wrapping `(module ...)` as a
         // script.
         LocationGuard guard{tokenizer};
-        WASP_TRY_READ(module, ReadModule(tokenizer, context));
+        WASP_TRY_READ(module, ReadModule(tokenizer, ctx));
         auto script_module = At{
             guard.loc(), ScriptModule{nullopt, ScriptModuleKind::Text, module}};
         return At{script_module.loc(), Command{script_module.value()}};
       } else {
-        context.errors.OnError(token.loc,
-                               concat("Invalid command, got ", token.type));
+        ctx.errors.OnError(token.loc,
+                           concat("Invalid command, got ", token.type));
         return nullopt;
       }
     }
   }
 }
 
-auto ReadScript(Tokenizer& tokenizer, Context& context) -> optional<Script> {
+auto ReadScript(Tokenizer& tokenizer, ReadCtx& ctx) -> optional<Script> {
   Script result;
   while (IsCommand(tokenizer)) {
-    WASP_TRY_READ(command, ReadCommand(tokenizer, context));
+    WASP_TRY_READ(command, ReadCommand(tokenizer, ctx));
     result.push_back(command);
   }
   return result;
 }
 
-
 // Explicit instantiations.
-template auto ReadFloatResult<f32>(Tokenizer&, Context&) -> OptAt<FloatResult<f32>>;
-template auto ReadFloatResult<f64>(Tokenizer&, Context&) -> OptAt<FloatResult<f64>>;
-template auto ReadSimdFloatResult<f32, 4>(Tokenizer&, Context&) -> OptAt<ReturnResult>;
-template auto ReadSimdFloatResult<f64, 2>(Tokenizer&, Context&) -> OptAt<ReturnResult>;
+template auto ReadFloatResult<f32>(Tokenizer&, ReadCtx&) -> OptAt<FloatResult<f32>>;
+template auto ReadFloatResult<f64>(Tokenizer&, ReadCtx&) -> OptAt<FloatResult<f64>>;
+template auto ReadSimdFloatResult<f32, 4>(Tokenizer&, ReadCtx&) -> OptAt<ReturnResult>;
+template auto ReadSimdFloatResult<f64, 2>(Tokenizer&, ReadCtx&) -> OptAt<ReturnResult>;
 
 }  // namespace wasp::text

--- a/src/text/resolve.cc
+++ b/src/text/resolve.cc
@@ -20,15 +20,13 @@
 
 #include "wasp/base/errors.h"
 #include "wasp/text/formatters.h"
-#include "wasp/text/resolve_context.h"
+#include "wasp/text/resolve_ctx.h"
 
 #include "wasp/base/concat.h"
 
 namespace wasp::text {
 
-void Define(ResolveContext& context,
-            const OptAt<BindVar>& var,
-            NameMap& name_map) {
+void Define(ResolveCtx& ctx, const OptAt<BindVar>& var, NameMap& name_map) {
   if (var) {
     auto& name = **var;
     if (!name_map.HasSinceLastPush(name)) {
@@ -37,160 +35,158 @@ void Define(ResolveContext& context,
     }
 
     // Use the previous name and treat this object as unbound.
-    context.errors.OnError(
-        var->loc(), concat("Variable ", name, " is already bound to index ",
-                           name_map.Get(name)));
+    ctx.errors.OnError(var->loc(),
+                       concat("Variable ", name, " is already bound to index ",
+                              name_map.Get(name)));
   }
 
   name_map.NewUnbound();
 }
 
-void Define(ResolveContext& context,
+void Define(ResolveCtx& ctx,
             const BoundValueTypeList& bvts,
             NameMap& name_map) {
   for (auto& bvt : bvts) {
-    Define(context, bvt->name, name_map);
+    Define(ctx, bvt->name, name_map);
   }
 }
 
-void Define(ResolveContext& context,
-            const FieldType& field_type,
-            NameMap& name_map) {
-  Define(context, field_type.name, name_map);
+void Define(ResolveCtx& ctx, const FieldType& field_type, NameMap& name_map) {
+  Define(ctx, field_type.name, name_map);
 }
 
-void Define(ResolveContext& context,
+void Define(ResolveCtx& ctx,
             const FieldTypeList& field_type_list,
             NameMap& name_map) {
   for (const auto& field_type : field_type_list) {
-    Define(context, field_type->name, name_map);
+    Define(ctx, field_type->name, name_map);
   }
 }
 
-void DefineTypes(ResolveContext& context, const DefinedType& defined_type) {
-  Index type_index = context.type_names.Size();
-  Define(context, defined_type.name, context.type_names);
+void DefineTypes(ResolveCtx& ctx, const DefinedType& defined_type) {
+  Index type_index = ctx.type_names.Size();
+  Define(ctx, defined_type.name, ctx.type_names);
 
   if (!defined_type.is_function_type()) {
-    auto& name_map = context.NewFieldNameMap(type_index);
+    auto& name_map = ctx.NewFieldNameMap(type_index);
     if (defined_type.is_struct_type()) {
-      Define(context, defined_type.struct_type()->fields, name_map);
+      Define(ctx, defined_type.struct_type()->fields, name_map);
     } else if (defined_type.is_array_type()) {
-      Define(context, defined_type.array_type()->field, name_map);
+      Define(ctx, defined_type.array_type()->field, name_map);
     }
   }
 }
 
-void Define(ResolveContext& context, const DefinedType& defined_type) {
+void Define(ResolveCtx& ctx, const DefinedType& defined_type) {
   // Resolve the type, in case the params or results have a value type that
   // uses a name, e.g. `(type (func (param (ref $T))))`.
   //
   // Since Resolve() changes its parameter, we make a copy first. The type
-  // entry is resolved later below in `Resolve(ResolveContext&, DefinedType&)`.
+  // entry is resolved later below in `Resolve(ResolveCtx&, DefinedType&)`.
 
   if (defined_type.is_function_type()) {
     BoundFunctionType bft = defined_type.function_type();
-    Resolve(context, bft);
-    context.function_type_map.Define(bft);
+    Resolve(ctx, bft);
+    ctx.function_type_map.Define(bft);
   } else {
-    context.function_type_map.SkipIndex();
+    ctx.function_type_map.SkipIndex();
   }
 }
 
-void Define(ResolveContext& context, const FunctionDesc& desc) {
-  Define(context, desc.name, context.function_names);
+void Define(ResolveCtx& ctx, const FunctionDesc& desc) {
+  Define(ctx, desc.name, ctx.function_names);
 }
 
-void Define(ResolveContext& context, const TableDesc& desc) {
-  Define(context, desc.name, context.table_names);
+void Define(ResolveCtx& ctx, const TableDesc& desc) {
+  Define(ctx, desc.name, ctx.table_names);
 }
 
-void Define(ResolveContext& context, const MemoryDesc& desc) {
-  Define(context, desc.name, context.memory_names);
+void Define(ResolveCtx& ctx, const MemoryDesc& desc) {
+  Define(ctx, desc.name, ctx.memory_names);
 }
 
-void Define(ResolveContext& context, const GlobalDesc& desc) {
-  Define(context, desc.name, context.global_names);
+void Define(ResolveCtx& ctx, const GlobalDesc& desc) {
+  Define(ctx, desc.name, ctx.global_names);
 }
 
-void Define(ResolveContext& context, const EventDesc& desc) {
-  Define(context, desc.name, context.event_names);
+void Define(ResolveCtx& ctx, const EventDesc& desc) {
+  Define(ctx, desc.name, ctx.event_names);
 }
 
-void Define(ResolveContext& context, const Import& import) {
+void Define(ResolveCtx& ctx, const Import& import) {
   switch (import.kind()) {
     case ExternalKind::Function:
-      Define(context, import.function_desc());
+      Define(ctx, import.function_desc());
       break;
 
     case ExternalKind::Table:
-      Define(context, import.table_desc());
+      Define(ctx, import.table_desc());
       break;
 
     case ExternalKind::Memory:
-      Define(context, import.memory_desc());
+      Define(ctx, import.memory_desc());
       break;
 
     case ExternalKind::Global:
-      Define(context, import.global_desc());
+      Define(ctx, import.global_desc());
       break;
 
     case ExternalKind::Event:
-      Define(context, import.event_desc());
+      Define(ctx, import.event_desc());
       break;
   }
 }
 
-void Define(ResolveContext& context, const ElementSegment& segment) {
-  Define(context, segment.name, context.element_segment_names);
+void Define(ResolveCtx& ctx, const ElementSegment& segment) {
+  Define(ctx, segment.name, ctx.element_segment_names);
 }
 
-void Define(ResolveContext& context, const DataSegment& segment) {
-  Define(context, segment.name, context.data_segment_names);
+void Define(ResolveCtx& ctx, const DataSegment& segment) {
+  Define(ctx, segment.name, ctx.data_segment_names);
 }
 
-void DefineTypes(ResolveContext& context, const ModuleItem& item) {
+void DefineTypes(ResolveCtx& ctx, const ModuleItem& item) {
   if (item.is_defined_type()) {
-    DefineTypes(context, item.defined_type());
+    DefineTypes(ctx, item.defined_type());
   }
 }
 
-void Define(ResolveContext& context, const ModuleItem& item) {
+void Define(ResolveCtx& ctx, const ModuleItem& item) {
   switch (item.kind()) {
     case ModuleItemKind::DefinedType:
-      Define(context, item.defined_type());
+      Define(ctx, item.defined_type());
       break;
 
     case ModuleItemKind::Import:
-      Define(context, item.import());
+      Define(ctx, item.import());
       break;
 
     case ModuleItemKind::Function:
-      Define(context, item.function()->desc);
+      Define(ctx, item.function()->desc);
       break;
 
     case ModuleItemKind::Table:
-      Define(context, item.table()->desc);
+      Define(ctx, item.table()->desc);
       break;
 
     case ModuleItemKind::Memory:
-      Define(context, item.memory()->desc);
+      Define(ctx, item.memory()->desc);
       break;
 
     case ModuleItemKind::Global:
-      Define(context, item.global()->desc);
+      Define(ctx, item.global()->desc);
       break;
 
     case ModuleItemKind::ElementSegment:
-      Define(context, item.element_segment());
+      Define(ctx, item.element_segment());
       break;
 
     case ModuleItemKind::DataSegment:
-      Define(context, item.data_segment());
+      Define(ctx, item.data_segment());
       break;
 
     case ModuleItemKind::Event:
-      Define(context, item.event()->desc);
+      Define(ctx, item.event()->desc);
       break;
 
     case ModuleItemKind::Export:
@@ -199,29 +195,29 @@ void Define(ResolveContext& context, const ModuleItem& item) {
   }
 }
 
-void DefineTypes(ResolveContext& context, const Module& module) {
+void DefineTypes(ResolveCtx& ctx, const Module& module) {
   for (const auto& item : module) {
-    DefineTypes(context, item);
+    DefineTypes(ctx, item);
   }
 }
 
-void Define(ResolveContext& context, const Module& module) {
+void Define(ResolveCtx& ctx, const Module& module) {
   for (const auto& item : module) {
-    Define(context, item);
+    Define(ctx, item);
   }
 }
 
 void Resolve(Module& module, Errors& errors) {
-  ResolveContext context{errors};
-  Resolve(context, module);
+  ResolveCtx ctx{errors};
+  Resolve(ctx, module);
 }
 
 void Resolve(Script& script, Errors& errors) {
-  ResolveContext context{errors};
-  Resolve(context, script);
+  ResolveCtx ctx{errors};
+  Resolve(ctx, script);
 }
 
-void Resolve(ResolveContext& context, At<Var>& var, NameMap& name_map) {
+void Resolve(ResolveCtx& ctx, At<Var>& var, NameMap& name_map) {
   if (var->is_index()) {
     return;
   }
@@ -229,90 +225,90 @@ void Resolve(ResolveContext& context, At<Var>& var, NameMap& name_map) {
   auto name = var->name();
   auto opt_index = name_map.Get(name);
   if (!opt_index) {
-    context.errors.OnError(var.loc(), concat("Undefined variable ", name));
+    ctx.errors.OnError(var.loc(), concat("Undefined variable ", name));
     return;
   }
 
   var->desc = *opt_index;
 }
 
-void Resolve(ResolveContext& context, OptAt<Var>& var, NameMap& name_map) {
+void Resolve(ResolveCtx& ctx, OptAt<Var>& var, NameMap& name_map) {
   if (var) {
-    Resolve(context, *var, name_map);
+    Resolve(ctx, *var, name_map);
   }
 }
 
-void Resolve(ResolveContext& context, VarList& var_list, NameMap& name_map) {
+void Resolve(ResolveCtx& ctx, VarList& var_list, NameMap& name_map) {
   for (auto& var : var_list) {
-    Resolve(context, var, name_map);
+    Resolve(ctx, var, name_map);
   }
 }
 
-void Resolve(ResolveContext& context, HeapType& heap_type) {
+void Resolve(ResolveCtx& ctx, HeapType& heap_type) {
   if (heap_type.is_var()) {
-    Resolve(context, heap_type.var(), context.type_names);
+    Resolve(ctx, heap_type.var(), ctx.type_names);
   }
 }
 
-void Resolve(ResolveContext& context, RefType& ref_type) {
-  Resolve(context, ref_type.heap_type.value());
+void Resolve(ResolveCtx& ctx, RefType& ref_type) {
+  Resolve(ctx, ref_type.heap_type.value());
 }
 
-void Resolve(ResolveContext& context, ReferenceType& reference_type) {
+void Resolve(ResolveCtx& ctx, ReferenceType& reference_type) {
   if (reference_type.is_ref()) {
-    Resolve(context, reference_type.ref().value());
+    Resolve(ctx, reference_type.ref().value());
   }
 }
 
-void Resolve(ResolveContext& context, Rtt& rtt) {
-  Resolve(context, rtt.type.value());
+void Resolve(ResolveCtx& ctx, Rtt& rtt) {
+  Resolve(ctx, rtt.type.value());
 }
 
-void Resolve(ResolveContext& context, ValueType& value_type) {
+void Resolve(ResolveCtx& ctx, ValueType& value_type) {
   if (value_type.is_reference_type()) {
-    Resolve(context, value_type.reference_type().value());
+    Resolve(ctx, value_type.reference_type().value());
   } else if (value_type.is_rtt()) {
-    Resolve(context, value_type.rtt().value());
+    Resolve(ctx, value_type.rtt().value());
   }
 }
 
-void Resolve(ResolveContext& context, ValueTypeList& value_type_list) {
+void Resolve(ResolveCtx& ctx, ValueTypeList& value_type_list) {
   for (auto& value_type : value_type_list) {
-    Resolve(context, value_type.value());
+    Resolve(ctx, value_type.value());
   }
 }
 
-void Resolve(ResolveContext& context, StorageType& storage_type) {
+void Resolve(ResolveCtx& ctx, StorageType& storage_type) {
   if (storage_type.is_value_type()) {
-    Resolve(context, storage_type.value_type().value());
+    Resolve(ctx, storage_type.value_type().value());
   }
 }
 
-void Resolve(ResolveContext& context, FunctionType& function_type) {
-  Resolve(context, function_type.params);
-  Resolve(context, function_type.results);
+void Resolve(ResolveCtx& ctx, FunctionType& function_type) {
+  Resolve(ctx, function_type.params);
+  Resolve(ctx, function_type.results);
 }
 
-void Resolve(ResolveContext& context, FunctionTypeUse& function_type_use) {
+void Resolve(ResolveCtx& ctx, FunctionTypeUse& function_type_use) {
   auto& type_use = function_type_use.type_use;
   auto& type = function_type_use.type;
 
-  Resolve(context, type_use, context.type_names);
-  Resolve(context, type.value());
+  Resolve(ctx, type_use, ctx.type_names);
+  Resolve(ctx, type.value());
 
   if (type_use) {
     if (type_use->value().is_index()) {
       auto type_index = type_use->value().index();
-      auto type_opt = context.function_type_map.Get(type_index);
+      auto type_opt = ctx.function_type_map.Get(type_index);
       bool has_explicit_params_or_results =
           type->params.size() || type->results.size();
       if (type_opt) {
         if (has_explicit_params_or_results) {
           // Explicit params/results, so check that they match.
           if (type != *type_opt) {
-            context.errors.OnError(
-                type.loc(), concat("Type use ", type_use,
-                                   " does not match explicit type ", type));
+            ctx.errors.OnError(type.loc(),
+                               concat("Type use ", type_use,
+                                      " does not match explicit type ", type));
           }
         } else {
           // No params/results given, so populate them.
@@ -321,42 +317,41 @@ void Resolve(ResolveContext& context, FunctionTypeUse& function_type_use) {
       } else if (has_explicit_params_or_results) {
         // We can't compare the type index to the explicit params/results, so
         // this must be considered a syntax error.
-        context.errors.OnError(type_use->loc(),
-                               concat("Invalid type index ", type_use));
+        ctx.errors.OnError(type_use->loc(),
+                           concat("Invalid type index ", type_use));
       }
     }
   } else {
-    auto index = context.function_type_map.Use(type);
+    auto index = ctx.function_type_map.Use(type);
     type_use = Var{index};
   }
 }
 
-void Resolve(ResolveContext& context, BoundValueType& bound_value_type) {
-  Resolve(context, bound_value_type.type.value());
+void Resolve(ResolveCtx& ctx, BoundValueType& bound_value_type) {
+  Resolve(ctx, bound_value_type.type.value());
 }
 
-void Resolve(ResolveContext& context,
-             BoundValueTypeList& bound_value_type_list) {
+void Resolve(ResolveCtx& ctx, BoundValueTypeList& bound_value_type_list) {
   for (auto& bound_value_type : bound_value_type_list) {
-    Resolve(context, bound_value_type.value());
+    Resolve(ctx, bound_value_type.value());
   }
 }
 
-void Resolve(ResolveContext& context, BoundFunctionType& bound_function_type) {
-  Resolve(context, bound_function_type.params);
-  Resolve(context, bound_function_type.results);
+void Resolve(ResolveCtx& ctx, BoundFunctionType& bound_function_type) {
+  Resolve(ctx, bound_function_type.params);
+  Resolve(ctx, bound_function_type.results);
 }
 
 // TODO: How to combine this with the function above?
-void Resolve(ResolveContext& context,
+void Resolve(ResolveCtx& ctx,
              OptAt<Var>& type_use,
              At<BoundFunctionType>& type) {
-  Resolve(context, type_use, context.type_names);
-  Resolve(context, type.value());
+  Resolve(ctx, type_use, ctx.type_names);
+  Resolve(ctx, type.value());
   if (type_use) {
     if (type_use->value().is_index()) {
       auto type_index = type_use->value().index();
-      auto type_opt = context.function_type_map.Get(type_index);
+      auto type_opt = ctx.function_type_map.Get(type_index);
       bool has_explicit_params_or_results =
           type->params.size() || type->results.size();
       if (type_opt) {
@@ -364,9 +359,9 @@ void Resolve(ResolveContext& context,
           // Explicit params/results, so check that they match.
           if (type->params != type_opt->params ||
               type->results != type_opt->results) {
-            context.errors.OnError(
-                type.loc(), concat("Type use ", type_use,
-                                   " does not match explicit type ", type));
+            ctx.errors.OnError(type.loc(),
+                               concat("Type use ", type_use,
+                                      " does not match explicit type ", type));
           }
         } else {
           // No params/results given, so populate them.
@@ -375,123 +370,121 @@ void Resolve(ResolveContext& context,
       } else if (has_explicit_params_or_results) {
         // We can't compare the type index to the explicit params/results, so
         // this must be considered a syntax error.
-        context.errors.OnError(type_use->loc(),
-                               concat("Invalid type index ", type_use));
+        ctx.errors.OnError(type_use->loc(),
+                           concat("Invalid type index ", type_use));
       }
     }
   } else {
-    auto index = context.function_type_map.Use(type);
+    auto index = ctx.function_type_map.Use(type);
     type_use = Var{index};
   }
 
-  Define(context, type->params, context.local_names);
+  Define(ctx, type->params, ctx.local_names);
 }
 
-void Resolve(ResolveContext& context, FieldType& field_type) {
-  Resolve(context, field_type.type.value());
+void Resolve(ResolveCtx& ctx, FieldType& field_type) {
+  Resolve(ctx, field_type.type.value());
 }
 
-void Resolve(ResolveContext& context, FieldTypeList& field_type_list) {
+void Resolve(ResolveCtx& ctx, FieldTypeList& field_type_list) {
   for (auto& field_type : field_type_list) {
-    Resolve(context, field_type.value());
+    Resolve(ctx, field_type.value());
   }
 }
 
-void Resolve(ResolveContext& context, StructType& struct_type) {
-  Resolve(context, struct_type.fields);
+void Resolve(ResolveCtx& ctx, StructType& struct_type) {
+  Resolve(ctx, struct_type.fields);
 }
 
-void Resolve(ResolveContext& context, ArrayType& array_type) {
-  Resolve(context, array_type.field.value());
+void Resolve(ResolveCtx& ctx, ArrayType& array_type) {
+  Resolve(ctx, array_type.field.value());
 }
 
-void Resolve(ResolveContext& context, DefinedType& defined_type) {
+void Resolve(ResolveCtx& ctx, DefinedType& defined_type) {
   if (defined_type.is_function_type()) {
-    Resolve(context, defined_type.function_type().value());
+    Resolve(ctx, defined_type.function_type().value());
   } else if (defined_type.is_struct_type()) {
-    Resolve(context, defined_type.struct_type().value());
+    Resolve(ctx, defined_type.struct_type().value());
   } else {
     assert(defined_type.is_array_type());
-    Resolve(context, defined_type.array_type().value());
+    Resolve(ctx, defined_type.array_type().value());
   }
 }
 
-void Resolve(ResolveContext& context, BlockImmediate& immediate) {
-  Define(context, immediate.label, context.label_names);
+void Resolve(ResolveCtx& ctx, BlockImmediate& immediate) {
+  Define(ctx, immediate.label, ctx.label_names);
   if (immediate.type.IsInlineType()) {
     // An inline type still may be `(result (ref $T))`, which needs to be
     // resolved.
-    Resolve(context, immediate.type.type.value());
+    Resolve(ctx, immediate.type.type.value());
   } else {
-    Resolve(context, immediate.type);
+    Resolve(ctx, immediate.type);
   }
 }
 
-void Resolve(ResolveContext& context, BrOnCastImmediate& immediate) {
-  Resolve(context, immediate.target, context.label_names);
-  Resolve(context, immediate.types);
+void Resolve(ResolveCtx& ctx, BrOnCastImmediate& immediate) {
+  Resolve(ctx, immediate.target, ctx.label_names);
+  Resolve(ctx, immediate.types);
 }
 
-void Resolve(ResolveContext& context, BrOnExnImmediate& immediate) {
-  Resolve(context, immediate.target, context.label_names);
-  Resolve(context, immediate.event, context.event_names);
+void Resolve(ResolveCtx& ctx, BrOnExnImmediate& immediate) {
+  Resolve(ctx, immediate.target, ctx.label_names);
+  Resolve(ctx, immediate.event, ctx.event_names);
 }
 
-void Resolve(ResolveContext& context, BrTableImmediate& immediate) {
-  Resolve(context, immediate.targets, context.label_names);
-  Resolve(context, immediate.default_target, context.label_names);
+void Resolve(ResolveCtx& ctx, BrTableImmediate& immediate) {
+  Resolve(ctx, immediate.targets, ctx.label_names);
+  Resolve(ctx, immediate.default_target, ctx.label_names);
 }
 
-void Resolve(ResolveContext& context, CallIndirectImmediate& immediate) {
-  Resolve(context, immediate.table, context.table_names);
-  Resolve(context, immediate.type);
+void Resolve(ResolveCtx& ctx, CallIndirectImmediate& immediate) {
+  Resolve(ctx, immediate.table, ctx.table_names);
+  Resolve(ctx, immediate.type);
 }
 
-void Resolve(ResolveContext& context,
-             CopyImmediate& immediate,
-             NameMap& name_map) {
-  Resolve(context, immediate.dst, name_map);
-  Resolve(context, immediate.src, name_map);
+void Resolve(ResolveCtx& ctx, CopyImmediate& immediate, NameMap& name_map) {
+  Resolve(ctx, immediate.dst, name_map);
+  Resolve(ctx, immediate.src, name_map);
 }
 
-void Resolve(ResolveContext& context, HeapType2Immediate& immediate) {
-  Resolve(context, immediate.parent.value());
-  Resolve(context, immediate.child.value());
+void Resolve(ResolveCtx& ctx, HeapType2Immediate& immediate) {
+  Resolve(ctx, immediate.parent.value());
+  Resolve(ctx, immediate.child.value());
 }
 
-void Resolve(ResolveContext& context,
+void Resolve(ResolveCtx& ctx,
              InitImmediate& immediate,
              NameMap& segment_name_map,
              NameMap& dst_name_map) {
-  Resolve(context, immediate.segment, segment_name_map);
-  Resolve(context, immediate.dst, dst_name_map);
+  Resolve(ctx, immediate.segment, segment_name_map);
+  Resolve(ctx, immediate.dst, dst_name_map);
 }
 
-void Resolve(ResolveContext& context, LetImmediate& immediate) {
-  Resolve(context, immediate.block);
-  Define(context, immediate.locals, context.local_names);
-  Resolve(context, immediate.locals);
+void Resolve(ResolveCtx& ctx, LetImmediate& immediate) {
+  Resolve(ctx, immediate.block);
+  Define(ctx, immediate.locals, ctx.local_names);
+  Resolve(ctx, immediate.locals);
 }
 
-void Resolve(ResolveContext& context, RttSubImmediate& immediate) {
-  Resolve(context, immediate.types);
+void Resolve(ResolveCtx& ctx, RttSubImmediate& immediate) {
+  Resolve(ctx, immediate.types);
 }
 
-void Resolve(ResolveContext& context, StructFieldImmediate& immediate) {
-  Resolve(context, immediate.struct_, context.type_names);
+void Resolve(ResolveCtx& ctx, StructFieldImmediate& immediate) {
+  Resolve(ctx, immediate.struct_, ctx.type_names);
   if (immediate.struct_->is_index()) {
     if (auto* field_name_map =
-            context.GetFieldNameMap(immediate.struct_->index())) {
-      Resolve(context, immediate.field, *field_name_map);
+            ctx.GetFieldNameMap(immediate.struct_->index())) {
+      Resolve(ctx, immediate.field, *field_name_map);
     }
   }
 }
 
-void Resolve(ResolveContext& context, Instruction& instruction) {
+void Resolve(ResolveCtx& ctx, Instruction& instruction) {
   switch (instruction.kind()) {
     case InstructionKind::None:
       if (instruction.opcode == Opcode::End) {
-        context.EndBlock();
+        ctx.EndBlock();
       }
       break;
 
@@ -508,13 +501,13 @@ void Resolve(ResolveContext& context, Instruction& instruction) {
         case Opcode::ArrayLen:
         case Opcode::StructNewWithRtt:
         case Opcode::StructNewDefaultWithRtt:
-          return Resolve(context, immediate, context.type_names);
+          return Resolve(ctx, immediate, ctx.type_names);
 
         // Function.
         case Opcode::Call:
         case Opcode::ReturnCall:
         case Opcode::RefFunc:
-          return Resolve(context, immediate, context.function_names);
+          return Resolve(ctx, immediate, ctx.function_names);
 
         // Table.
         case Opcode::TableFill:
@@ -522,42 +515,42 @@ void Resolve(ResolveContext& context, Instruction& instruction) {
         case Opcode::TableGrow:
         case Opcode::TableSet:
         case Opcode::TableSize:
-          return Resolve(context, immediate, context.table_names);
+          return Resolve(ctx, immediate, ctx.table_names);
 
         // Global.
         case Opcode::GlobalGet:
         case Opcode::GlobalSet:
-          return Resolve(context, immediate, context.global_names);
+          return Resolve(ctx, immediate, ctx.global_names);
 
         // Event.
         case Opcode::Throw:
-          return Resolve(context, immediate, context.event_names);
+          return Resolve(ctx, immediate, ctx.event_names);
 
         // Element Segment.
         case Opcode::ElemDrop:
-          return Resolve(context, immediate, context.element_segment_names);
+          return Resolve(ctx, immediate, ctx.element_segment_names);
 
         // Data Segment.
         case Opcode::MemoryInit:
         case Opcode::DataDrop:
-          return Resolve(context, immediate, context.data_segment_names);
+          return Resolve(ctx, immediate, ctx.data_segment_names);
 
         // Label.
         case Opcode::BrIf:
         case Opcode::Br:
         case Opcode::BrOnNull:
-        // TODO: Keep if br_on_cast continues to use var immediate instead of
-        // BrOnExnImmediate.
+          // TODO: Keep if br_on_cast continues to use var immediate instead of
+          // BrOnExnImmediate.
 #if 1
         case Opcode::BrOnCast:
 #endif
-          return Resolve(context, immediate, context.label_names);
+          return Resolve(ctx, immediate, ctx.label_names);
 
         // Local.
         case Opcode::LocalGet:
         case Opcode::LocalSet:
         case Opcode::LocalTee:
-          return Resolve(context, immediate, context.local_names);
+          return Resolve(ctx, immediate, ctx.local_names);
 
         default:
           break;
@@ -566,159 +559,158 @@ void Resolve(ResolveContext& context, Instruction& instruction) {
     }
 
     case InstructionKind::Block:
-      context.BeginBlock(instruction.opcode);
-      return Resolve(context, instruction.block_immediate().value());
+      ctx.BeginBlock(instruction.opcode);
+      return Resolve(ctx, instruction.block_immediate().value());
 
     case InstructionKind::BrOnExn:
-      return Resolve(context, instruction.br_on_exn_immediate().value());
+      return Resolve(ctx, instruction.br_on_exn_immediate().value());
 
     case InstructionKind::BrTable:
-      return Resolve(context, instruction.br_table_immediate().value());
+      return Resolve(ctx, instruction.br_table_immediate().value());
 
     case InstructionKind::CallIndirect:
-      return Resolve(context, instruction.call_indirect_immediate().value());
+      return Resolve(ctx, instruction.call_indirect_immediate().value());
 
     case InstructionKind::Copy: {
       auto& immediate = instruction.copy_immediate();
       if (instruction.opcode == Opcode::TableCopy) {
-        return Resolve(context, immediate.value(), context.table_names);
+        return Resolve(ctx, immediate.value(), ctx.table_names);
       } else {
         assert(instruction.opcode == Opcode::MemoryCopy);
-        return Resolve(context, immediate.value(), context.memory_names);
+        return Resolve(ctx, immediate.value(), ctx.memory_names);
       }
     }
 
     case InstructionKind::Init: {
       auto& immediate = instruction.init_immediate();
       if (instruction.opcode == Opcode::MemoryInit) {
-        return Resolve(context, immediate.value(), context.data_segment_names,
-                       context.memory_names);
+        return Resolve(ctx, immediate.value(), ctx.data_segment_names,
+                       ctx.memory_names);
       } else {
-        return Resolve(context, immediate.value(),
-                       context.element_segment_names, context.table_names);
+        return Resolve(ctx, immediate.value(), ctx.element_segment_names,
+                       ctx.table_names);
       }
     }
 
     case InstructionKind::Let:
-      context.BeginBlock(instruction.opcode);
-      return Resolve(context, instruction.let_immediate().value());
+      ctx.BeginBlock(instruction.opcode);
+      return Resolve(ctx, instruction.let_immediate().value());
 
     case InstructionKind::HeapType: {
       auto& immediate = instruction.heap_type_immediate();
       if (immediate->is_var()) {
-        return Resolve(context, immediate->var(), context.type_names);
+        return Resolve(ctx, immediate->var(), ctx.type_names);
       }
       break;
     }
 
     case InstructionKind::Select:
-      return Resolve(context, instruction.select_immediate().value());
+      return Resolve(ctx, instruction.select_immediate().value());
 
     case InstructionKind::FuncBind:
-      return Resolve(context, instruction.func_bind_immediate().value());
+      return Resolve(ctx, instruction.func_bind_immediate().value());
 
     case InstructionKind::BrOnCast:
-      return Resolve(context, instruction.br_on_cast_immediate().value());
+      return Resolve(ctx, instruction.br_on_cast_immediate().value());
 
     case InstructionKind::HeapType2:
-      return Resolve(context, instruction.heap_type_2_immediate().value());
+      return Resolve(ctx, instruction.heap_type_2_immediate().value());
 
     case InstructionKind::RttSub:
-      return Resolve(context, instruction.rtt_sub_immediate().value());
+      return Resolve(ctx, instruction.rtt_sub_immediate().value());
 
     case InstructionKind::StructField:
-      return Resolve(context, instruction.struct_field_immediate().value());
+      return Resolve(ctx, instruction.struct_field_immediate().value());
 
     default:
       break;
   }
 }
 
-void Resolve(ResolveContext& context, InstructionList& instructions) {
+void Resolve(ResolveCtx& ctx, InstructionList& instructions) {
   for (auto& instruction : instructions) {
-    Resolve(context, instruction.value());
+    Resolve(ctx, instruction.value());
   }
 }
 
-void Resolve(ResolveContext& context, FunctionDesc& desc) {
-  Resolve(context, desc.type_use, desc.type);
+void Resolve(ResolveCtx& ctx, FunctionDesc& desc) {
+  Resolve(ctx, desc.type_use, desc.type);
 }
 
-void Resolve(ResolveContext& context, TableType& table_type) {
-  Resolve(context, table_type.elemtype.value());
+void Resolve(ResolveCtx& ctx, TableType& table_type) {
+  Resolve(ctx, table_type.elemtype.value());
 }
 
-void Resolve(ResolveContext& context, TableDesc& desc) {
-  Resolve(context, desc.type.value());
+void Resolve(ResolveCtx& ctx, TableDesc& desc) {
+  Resolve(ctx, desc.type.value());
 }
 
-void Resolve(ResolveContext& context, GlobalType& global_type) {
-  Resolve(context, global_type.valtype.value());
+void Resolve(ResolveCtx& ctx, GlobalType& global_type) {
+  Resolve(ctx, global_type.valtype.value());
 }
 
-void Resolve(ResolveContext& context, GlobalDesc& desc) {
-  Resolve(context, desc.type.value());
+void Resolve(ResolveCtx& ctx, GlobalDesc& desc) {
+  Resolve(ctx, desc.type.value());
 }
 
-void Resolve(ResolveContext& context, EventType& event_type) {
-  Resolve(context, event_type.type);
+void Resolve(ResolveCtx& ctx, EventType& event_type) {
+  Resolve(ctx, event_type.type);
 }
 
-void Resolve(ResolveContext& context, EventDesc& desc) {
-  Resolve(context, desc.type.value());
+void Resolve(ResolveCtx& ctx, EventDesc& desc) {
+  Resolve(ctx, desc.type.value());
 }
 
-void Resolve(ResolveContext& context, Import& import) {
+void Resolve(ResolveCtx& ctx, Import& import) {
   switch (import.kind()) {
     case ExternalKind::Function:
-      return Resolve(context, import.function_desc());
+      return Resolve(ctx, import.function_desc());
 
     case ExternalKind::Table:
-      return Resolve(context, import.table_desc());
+      return Resolve(ctx, import.table_desc());
 
     case ExternalKind::Global:
-      return Resolve(context, import.global_desc());
+      return Resolve(ctx, import.global_desc());
 
     case ExternalKind::Event:
-      return Resolve(context, import.event_desc());
+      return Resolve(ctx, import.event_desc());
 
     default:
       break;
   }
 }
 
-void Resolve(ResolveContext& context, Function& function) {
-  context.BeginFunction();
-  Resolve(context, function.desc);
-  Define(context, function.locals, context.local_names);
-  Resolve(context, function.locals);
-  Resolve(context, function.instructions);
+void Resolve(ResolveCtx& ctx, Function& function) {
+  ctx.BeginFunction();
+  Resolve(ctx, function.desc);
+  Define(ctx, function.locals, ctx.local_names);
+  Resolve(ctx, function.locals);
+  Resolve(ctx, function.instructions);
 }
 
-void Resolve(ResolveContext& context, ConstantExpression& expression) {
-  Resolve(context, expression.instructions);
+void Resolve(ResolveCtx& ctx, ConstantExpression& expression) {
+  Resolve(ctx, expression.instructions);
 }
 
-void Resolve(ResolveContext& context, ElementExpression& expression) {
-  Resolve(context, expression.instructions);
+void Resolve(ResolveCtx& ctx, ElementExpression& expression) {
+  Resolve(ctx, expression.instructions);
 }
 
-void Resolve(ResolveContext& context, ElementExpressionList& expression_list) {
+void Resolve(ResolveCtx& ctx, ElementExpressionList& expression_list) {
   for (auto& expression : expression_list) {
-    Resolve(context, *expression);
+    Resolve(ctx, *expression);
   }
 }
 
-void Resolve(ResolveContext& context,
-             ElementListWithExpressions& element_list) {
-  Resolve(context, element_list.elemtype.value());
-  Resolve(context, element_list.list);
+void Resolve(ResolveCtx& ctx, ElementListWithExpressions& element_list) {
+  Resolve(ctx, element_list.elemtype.value());
+  Resolve(ctx, element_list.list);
 }
 
-void Resolve(ResolveContext& context, ElementListWithVars& element_list) {
+void Resolve(ResolveCtx& ctx, ElementListWithVars& element_list) {
   switch (element_list.kind) {
     case ExternalKind::Function:
-      return Resolve(context, element_list.list, context.function_names);
+      return Resolve(ctx, element_list.list, ctx.function_names);
 
     default:
       // Other external kinds not currently supported.
@@ -726,150 +718,150 @@ void Resolve(ResolveContext& context, ElementListWithVars& element_list) {
   }
 }
 
-void Resolve(ResolveContext& context, ElementList& element_list) {
+void Resolve(ResolveCtx& ctx, ElementList& element_list) {
   if (holds_alternative<ElementListWithVars>(element_list)) {
-    Resolve(context, get<ElementListWithVars>(element_list));
+    Resolve(ctx, get<ElementListWithVars>(element_list));
   } else {
-    Resolve(context, get<ElementListWithExpressions>(element_list));
+    Resolve(ctx, get<ElementListWithExpressions>(element_list));
   }
 }
 
-void Resolve(ResolveContext& context, Table& table) {
-  Resolve(context, table.desc);
+void Resolve(ResolveCtx& ctx, Table& table) {
+  Resolve(ctx, table.desc);
   if (table.elements) {
-    Resolve(context, *table.elements);
+    Resolve(ctx, *table.elements);
   }
 }
 
-void Resolve(ResolveContext& context, Global& global) {
-  Resolve(context, global.desc);
+void Resolve(ResolveCtx& ctx, Global& global) {
+  Resolve(ctx, global.desc);
   if (global.init) {
-    Resolve(context, global.init->value());
+    Resolve(ctx, global.init->value());
   }
 }
 
-void Resolve(ResolveContext& context, Export& export_) {
+void Resolve(ResolveCtx& ctx, Export& export_) {
   switch (export_.kind) {
     case ExternalKind::Function:
-      return Resolve(context, export_.var, context.function_names);
+      return Resolve(ctx, export_.var, ctx.function_names);
 
     case ExternalKind::Table:
-      return Resolve(context, export_.var, context.table_names);
+      return Resolve(ctx, export_.var, ctx.table_names);
 
     case ExternalKind::Memory:
-      return Resolve(context, export_.var, context.memory_names);
+      return Resolve(ctx, export_.var, ctx.memory_names);
 
     case ExternalKind::Global:
-      return Resolve(context, export_.var, context.global_names);
+      return Resolve(ctx, export_.var, ctx.global_names);
 
     case ExternalKind::Event:
-      return Resolve(context, export_.var, context.event_names);
+      return Resolve(ctx, export_.var, ctx.event_names);
 
     default:
       break;
   }
 }
 
-void Resolve(ResolveContext& context, Start& start) {
-  Resolve(context, start.var, context.function_names);
+void Resolve(ResolveCtx& ctx, Start& start) {
+  Resolve(ctx, start.var, ctx.function_names);
 }
 
-void Resolve(ResolveContext& context, ElementSegment& segment) {
-  Resolve(context, segment.table, context.table_names);
+void Resolve(ResolveCtx& ctx, ElementSegment& segment) {
+  Resolve(ctx, segment.table, ctx.table_names);
   if (segment.offset) {
-    Resolve(context, segment.offset->value());
+    Resolve(ctx, segment.offset->value());
   }
-  Resolve(context, segment.elements);
+  Resolve(ctx, segment.elements);
 }
 
-void Resolve(ResolveContext& context, DataSegment& segment) {
-  Resolve(context, segment.memory, context.memory_names);
+void Resolve(ResolveCtx& ctx, DataSegment& segment) {
+  Resolve(ctx, segment.memory, ctx.memory_names);
   if (segment.offset) {
-    Resolve(context, segment.offset->value());
+    Resolve(ctx, segment.offset->value());
   }
 }
 
-void Resolve(ResolveContext& context, Event& event) {
-  Resolve(context, event.desc);
+void Resolve(ResolveCtx& ctx, Event& event) {
+  Resolve(ctx, event.desc);
 }
 
-void Resolve(ResolveContext& context, ModuleItem& item) {
+void Resolve(ResolveCtx& ctx, ModuleItem& item) {
   switch (item.kind()) {
     case ModuleItemKind::DefinedType:
-      return Resolve(context, *item.defined_type());
+      return Resolve(ctx, *item.defined_type());
 
     case ModuleItemKind::Import:
-      return Resolve(context, *item.import());
+      return Resolve(ctx, *item.import());
 
     case ModuleItemKind::Function:
-      return Resolve(context, *item.function());
+      return Resolve(ctx, *item.function());
 
     case ModuleItemKind::Table:
-      return Resolve(context, *item.table());
+      return Resolve(ctx, *item.table());
 
     case ModuleItemKind::Global:
-      return Resolve(context, *item.global());
+      return Resolve(ctx, *item.global());
 
     case ModuleItemKind::Export:
-      return Resolve(context, *item.export_());
+      return Resolve(ctx, *item.export_());
 
     case ModuleItemKind::Start:
-      return Resolve(context, *item.start());
+      return Resolve(ctx, *item.start());
 
     case ModuleItemKind::ElementSegment:
-      return Resolve(context, *item.element_segment());
+      return Resolve(ctx, *item.element_segment());
 
     case ModuleItemKind::DataSegment:
-      return Resolve(context, *item.data_segment());
+      return Resolve(ctx, *item.data_segment());
 
     case ModuleItemKind::Event:
-      return Resolve(context, *item.event());
+      return Resolve(ctx, *item.event());
 
     default:
       break;
   }
 }
 
-void Resolve(ResolveContext& context, Module& module) {
-  context.BeginModule();
-  DefineTypes(context, module);
-  Define(context, module);
+void Resolve(ResolveCtx& ctx, Module& module) {
+  ctx.BeginModule();
+  DefineTypes(ctx, module);
+  Define(ctx, module);
   for (auto& item : module) {
-    Resolve(context, item);
+    Resolve(ctx, item);
   }
-  auto deferred_types = context.EndModule();
+  auto deferred_types = ctx.EndModule();
   for (auto& defined_type : deferred_types) {
     module.push_back(ModuleItem{defined_type});
   }
 }
 
-void Resolve(ResolveContext& context, ScriptModule& script_module) {
+void Resolve(ResolveCtx& ctx, ScriptModule& script_module) {
   if (script_module.has_module()) {
-    Resolve(context, script_module.module());
+    Resolve(ctx, script_module.module());
   }
 }
 
-void Resolve(ResolveContext& context, ModuleAssertion& module_assertion) {
-  Resolve(context, *module_assertion.module);
+void Resolve(ResolveCtx& ctx, ModuleAssertion& module_assertion) {
+  Resolve(ctx, *module_assertion.module);
 }
 
-void Resolve(ResolveContext& context, Assertion& assertion) {
+void Resolve(ResolveCtx& ctx, Assertion& assertion) {
   if (assertion.is_module_assertion()) {
-    Resolve(context, assertion.module_assertion());
+    Resolve(ctx, assertion.module_assertion());
   }
 }
 
-void Resolve(ResolveContext& context, Command& command) {
+void Resolve(ResolveCtx& ctx, Command& command) {
   if (command.is_script_module()) {
-    Resolve(context, command.script_module());
+    Resolve(ctx, command.script_module());
   } else if (command.is_assertion()) {
-    Resolve(context, command.assertion());
+    Resolve(ctx, command.assertion());
   }
 }
 
-void Resolve(ResolveContext& context, Script& script) {
-  for (auto& command: script) {
-    Resolve(context, *command);
+void Resolve(ResolveCtx& ctx, Script& script) {
+  for (auto& command : script) {
+    Resolve(ctx, *command);
   }
 }
 

--- a/src/text/resolve_ctx.cc
+++ b/src/text/resolve_ctx.cc
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-#include "wasp/text/resolve_context.h"
+#include "wasp/text/resolve_ctx.h"
 
 #include <algorithm>
 #include <cassert>
@@ -24,9 +24,9 @@
 
 namespace wasp::text {
 
-ResolveContext::ResolveContext(Errors& errors) : errors{errors} {}
+ResolveCtx::ResolveCtx(Errors& errors) : errors{errors} {}
 
-void ResolveContext::BeginModule() {
+void ResolveCtx::BeginModule() {
   type_names.Reset();
   field_names.clear();
   function_names.Reset();
@@ -40,14 +40,14 @@ void ResolveContext::BeginModule() {
   BeginFunction();
 }
 
-void ResolveContext::BeginFunction() {
+void ResolveCtx::BeginFunction() {
   local_names.Reset();
   label_names.Reset();
   blocks.clear();
   BeginBlock(Opcode::Unreachable);  // Begin dummy block for function.
 }
 
-void ResolveContext::BeginBlock(Opcode opcode) {
+void ResolveCtx::BeginBlock(Opcode opcode) {
   blocks.push_back(opcode);
   label_names.Push();
   if (opcode == Opcode::Let) {
@@ -55,7 +55,7 @@ void ResolveContext::BeginBlock(Opcode opcode) {
   }
 }
 
-void ResolveContext::EndBlock() {
+void ResolveCtx::EndBlock() {
   assert(!blocks.empty());
   if (blocks.back() == Opcode::Let) {
     local_names.Pop();
@@ -64,17 +64,17 @@ void ResolveContext::EndBlock() {
   blocks.pop_back();
 }
 
-auto ResolveContext::EndModule() -> DefinedTypeList {
+auto ResolveCtx::EndModule() -> DefinedTypeList {
   return function_type_map.EndModule();
 }
 
-auto ResolveContext::NewFieldNameMap(Index index) -> NameMap& {
+auto ResolveCtx::NewFieldNameMap(Index index) -> NameMap& {
   auto [iter, ok] = field_names.emplace(index, NameMap{});
   assert(ok);
   return iter->second;
 }
 
-auto ResolveContext::GetFieldNameMap(Index index) -> NameMap* {
+auto ResolveCtx::GetFieldNameMap(Index index) -> NameMap* {
   auto iter = field_names.find(index);
   if (iter == field_names.end()) {
     return nullptr;

--- a/src/tools/callgraph.cc
+++ b/src/tools/callgraph.cc
@@ -178,10 +178,10 @@ void Tool::CalculateCallGraph() {
     if (section->is_known()) {
       auto known = section->known();
       if (known->id == SectionId::Code) {
-        auto section = ReadCodeSection(known, module.context);
+        auto section = ReadCodeSection(known, module.ctx);
         for (auto code : enumerate(section.sequence, imported_function_count)) {
           for (const auto& instr :
-               ReadExpression(code.value->body, module.context)) {
+               ReadExpression(code.value->body, module.ctx)) {
             if (instr->opcode == Opcode::Call) {
               assert(instr->has_index_immediate());
               auto callee_index = instr->index_immediate();

--- a/src/tools/cfg.cc
+++ b/src/tools/cfg.cc
@@ -200,7 +200,7 @@ optional<Code> Tool::GetCode(Index find_index) {
     if (section->is_known()) {
       auto known = section->known();
       if (known->id == SectionId::Code) {
-        auto section = ReadCodeSection(known, module.context);
+        auto section = ReadCodeSection(known, module.ctx);
         for (auto code : enumerate(section.sequence, imported_function_count)) {
           if (code.index == find_index) {
             return code.value;
@@ -219,7 +219,7 @@ void Tool::CalculateCFG(Code code) {
   StartBasicBlock(start_bbid, ptr);
 
   const u8* prev_ptr = ptr;
-  auto instrs = ReadExpression(code.body, module.context);
+  auto instrs = ReadExpression(code.body, module.ctx);
   for (auto it = instrs.begin(), end = instrs.end(); it != end;
        ++it, prev_ptr = ptr) {
     const auto& instr = *it;
@@ -386,7 +386,7 @@ void Tool::WriteDotFile() {
              "<TABLE BORDER=\"1\" CELLBORDER=\"1\" CELLSPACING=\"0\"><TR>"
              "<TD BORDER=\"0\" ALIGN=\"LEFT\" COLSPAN=\"%d\">",
              bb.index, colspan);
-      auto instrs = ReadExpression(bb.value.code, module.context);
+      auto instrs = ReadExpression(bb.value.code, module.ctx);
       for (const auto& instr: instrs) {
         if (IsExtraneousInstruction(instr)) {
           continue;
@@ -485,7 +485,7 @@ void Tool::EndBasicBlock(const u8* end) {
   const u8* start = bb.code.data();
   bb.code = MakeSpan(start, end);
 
-  auto instrs = ReadExpression(bb.code, module.context);
+  auto instrs = ReadExpression(bb.code, module.ctx);
   if (std::all_of(instrs.begin(), instrs.end(), IsExtraneousInstruction)) {
     bb.code = SpanU8{};
   }

--- a/src/tools/dfg.cc
+++ b/src/tools/dfg.cc
@@ -236,14 +236,14 @@ void Tool::DoPrepass() {
       auto known = section->known();
       switch (known->id) {
         case SectionId::Type: {
-          auto seq = ReadTypeSection(known, module.context).sequence;
+          auto seq = ReadTypeSection(known, module.ctx).sequence;
           std::copy(seq.begin(), seq.end(), std::back_inserter(defined_types));
           break;
         }
 
         case SectionId::Import:
           for (auto import :
-               ReadImportSection(known, module.context).sequence) {
+               ReadImportSection(known, module.ctx).sequence) {
             if (import->kind() == ExternalKind::Function) {
               functions.push_back(Function{import->index()});
             }
@@ -252,7 +252,7 @@ void Tool::DoPrepass() {
           break;
 
         case SectionId::Function: {
-          auto seq = ReadFunctionSection(known, module.context).sequence;
+          auto seq = ReadFunctionSection(known, module.ctx).sequence;
           std::copy(seq.begin(), seq.end(), std::back_inserter(functions));
           break;
         }
@@ -295,7 +295,7 @@ optional<Code> Tool::GetCode(Index find_index) {
     if (section->is_known()) {
       auto known = section->known();
       if (known->id == SectionId::Code) {
-        auto section = ReadCodeSection(known, module.context);
+        auto section = ReadCodeSection(known, module.ctx);
         for (auto code : enumerate(section.sequence, imported_function_count)) {
           if (code.index == find_index) {
             return code.value;
@@ -356,7 +356,7 @@ void Tool::CalculateDFG(const FunctionType& type, Code code) {
   PushUndefValues(type.result_types.size());
   PushLabel(Opcode::Return, return_bbid, return_bbid);
 
-  for (const auto& instr : ReadExpression(code.body, module.context)) {
+  for (const auto& instr : ReadExpression(code.body, module.ctx)) {
     DoInstruction(instr);
   }
 

--- a/src/tools/pattern.cc
+++ b/src/tools/pattern.cc
@@ -168,7 +168,7 @@ visit::Result Tool::Visitor::BeginCodeSection(LazyCodeSection) {
 visit::Result Tool::Visitor::BeginCode(const At<Code>& code) {
   Instructions instructions;
 
-  auto instrs = ReadExpression(code->body, tool.module.context);
+  auto instrs = ReadExpression(code->body, tool.module.ctx);
   for (auto it = instrs.begin(), end = instrs.end(); it != end; ++it) {
     auto instr = *it;
 #if 0

--- a/src/tools/validate.cc
+++ b/src/tools/validate.cc
@@ -35,7 +35,7 @@
 #include "wasp/base/optional.h"
 #include "wasp/base/string_view.h"
 #include "wasp/binary/formatters.h"
-#include "wasp/valid/context.h"
+#include "wasp/valid/valid_ctx.h"
 #include "wasp/valid/validate_visitor.h"
 
 namespace wasp {

--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -32,13 +32,13 @@
 #include "wasp/binary/encoding.h"
 #include "wasp/binary/formatters.h"
 #include "wasp/binary/read.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 #include "wasp/binary/types.h"
 #include "wasp/convert/to_text.h"
 #include "wasp/text/formatters.h"
 #include "wasp/text/types.h"
 #include "wasp/text/write.h"
-#include "wasp/valid/context.h"
+#include "wasp/valid/valid_ctx.h"
 #include "wasp/valid/validate.h"
 
 namespace fs = std::filesystem;
@@ -117,7 +117,7 @@ Tool::Tool(string_view filename, SpanU8 data, Options options)
 
 int Tool::Run() {
   BinaryErrors errors{data};
-  binary::Context read_context{options.features, errors};
+  binary::ReadCtx read_context{options.features, errors};
   auto binary_module = binary::ReadModule(data, read_context);
   if (errors.HasError()) {
     errors.PrintTo(std::cerr);
@@ -125,7 +125,7 @@ int Tool::Run() {
   }
 
   if (options.validate) {
-    valid::Context validate_context{options.features, errors};
+    valid::ValidCtx validate_context{options.features, errors};
     valid::Validate(validate_context, *binary_module);
 
     if (errors.HasError()) {
@@ -134,10 +134,10 @@ int Tool::Run() {
     }
   }
 
-  convert::TextContext convert_context;
+  convert::TextCtx convert_context;
   auto text_module = convert::ToText(convert_context, *binary_module);
 
-  text::WriteContext write_context;
+  text::WriteCtx write_context;
   Buffer buffer;
   text::Write(write_context, text_module, std::back_inserter(buffer));
 

--- a/src/tools/wat2wasm.cc
+++ b/src/tools/wat2wasm.cc
@@ -37,11 +37,11 @@
 #include "wasp/convert/to_binary.h"
 #include "wasp/text/desugar.h"
 #include "wasp/text/read.h"
-#include "wasp/text/read/context.h"
+#include "wasp/text/read/read_ctx.h"
 #include "wasp/text/read/tokenizer.h"
 #include "wasp/text/resolve.h"
 #include "wasp/text/types.h"
-#include "wasp/valid/context.h"
+#include "wasp/valid/valid_ctx.h"
 #include "wasp/valid/validate.h"
 
 #include "wasp/text/formatters.h"
@@ -124,7 +124,7 @@ Tool::Tool(string_view filename, SpanU8 data, Options options)
 int Tool::Run() {
   text::Tokenizer tokenizer{data};
   tools::TextErrors errors{filename, data};
-  text::Context read_context{options.features, errors};
+  text::ReadCtx read_context{options.features, errors};
   auto text_module =
       ReadSingleModule(tokenizer, read_context).value_or(text::Module{});
   Expect(tokenizer, read_context, text::TokenType::Eof);
@@ -137,11 +137,11 @@ int Tool::Run() {
     return 1;
   }
 
-  convert::Context convert_context{options.features};
+  convert::BinCtx convert_context{options.features};
   auto binary_module = convert::ToBinary(convert_context, text_module);
 
   if (options.validate) {
-    valid::Context validate_context{options.features, errors};
+    valid::ValidCtx validate_context{options.features, errors};
     Validate(validate_context, binary_module);
 
     if (errors.HasError()) {

--- a/src/valid/CMakeLists.txt
+++ b/src/valid/CMakeLists.txt
@@ -15,22 +15,22 @@
 #
 
 add_library(libwasp_valid
-  ../../include/wasp/valid/context.h
   ../../include/wasp/valid/disjoint_set.h
   ../../include/wasp/valid/formatters.h
   ../../include/wasp/valid/local_map.h
   ../../include/wasp/valid/match.h
   ../../include/wasp/valid/types.h
+  ../../include/wasp/valid/valid_ctx.h
   ../../include/wasp/valid/validate.h
   ../../include/wasp/valid/validate_visitor.h
   ../../include/wasp/valid/stack_type.inc
 
-  context.cc
   disjoint_set.cc
   formatters.cc
   local_map.cc
   match.cc
   types.cc
+  valid_ctx.cc
   validate.cc
   validate_instruction.cc
   validate_visitor.cc

--- a/src/valid/match.cc
+++ b/src/valid/match.cc
@@ -18,7 +18,7 @@
 
 #include <cassert>
 
-#include "wasp/valid/context.h"
+#include "wasp/valid/valid_ctx.h"
 
 namespace wasp::valid {
 
@@ -31,7 +31,7 @@ auto CanonicalizeToRefType(const binary::ReferenceType& type)
 
 /// IsSame ///
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::HeapType& expected,
             const binary::HeapType& actual) {
   if (expected.is_heap_kind() && actual.is_heap_kind()) {
@@ -43,58 +43,58 @@ bool IsSame(Context& context,
       return true;
     }
 
-    auto is_same_opt = context.same_types.Get(expected_index, actual_index);
+    auto is_same_opt = ctx.same_types.Get(expected_index, actual_index);
     if (is_same_opt) {
       return *is_same_opt;
     }
 
     // Assume that they are the same and check that everything still is valid.
-    context.same_types.Assume(expected_index, actual_index);
-    bool is_same = IsSame(context, context.types[expected_index],
-                          context.types[actual_index]);
-    context.same_types.Resolve(expected_index, actual_index, is_same);
+    ctx.same_types.Assume(expected_index, actual_index);
+    bool is_same =
+        IsSame(ctx, ctx.types[expected_index], ctx.types[actual_index]);
+    ctx.same_types.Resolve(expected_index, actual_index, is_same);
     return is_same;
   }
   return false;
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::RefType& expected,
             const binary::RefType& actual) {
-  return IsSame(context, expected.heap_type, actual.heap_type) &&
+  return IsSame(ctx, expected.heap_type, actual.heap_type) &&
          expected.null == actual.null;
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::ReferenceType& expected,
             const binary::ReferenceType& actual) {
   // Canonicalize in case one of the types is "ref null X" and the other is
   // "Xref".
-  return IsSame(context, CanonicalizeToRefType(expected),
+  return IsSame(ctx, CanonicalizeToRefType(expected),
                 CanonicalizeToRefType(actual));
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::Rtt& expected,
             const binary::Rtt& actual) {
   return expected.depth.value() == actual.depth.value() &&
-         IsSame(context, expected.type, actual.type);
+         IsSame(ctx, expected.type, actual.type);
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::ValueType& expected,
             const binary::ValueType& actual) {
   if (expected.is_numeric_type() && actual.is_numeric_type()) {
     return expected.numeric_type().value() == actual.numeric_type().value();
   } else if (expected.is_reference_type() && actual.is_reference_type()) {
-    return IsSame(context, expected.reference_type(), actual.reference_type());
+    return IsSame(ctx, expected.reference_type(), actual.reference_type());
   } else if (expected.is_rtt() && actual.is_rtt()) {
-    return IsSame(context, expected.rtt(), actual.rtt());
+    return IsSame(ctx, expected.rtt(), actual.rtt());
   }
   return false;
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::ValueTypeList& expected,
             const binary::ValueTypeList& actual) {
   if (expected.size() != actual.size()) {
@@ -104,30 +104,28 @@ bool IsSame(Context& context,
   for (auto eiter = expected.begin(), lend = expected.end(),
             aiter = actual.begin();
        eiter != lend; ++eiter, ++aiter) {
-    if (!IsSame(context, *eiter, *aiter)) {
+    if (!IsSame(ctx, *eiter, *aiter)) {
       return false;
     }
   }
   return true;
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::FunctionType& expected,
             const binary::FunctionType& actual) {
-  return IsSame(context, expected.param_types, actual.param_types) &&
-         IsSame(context, expected.result_types, actual.result_types);
+  return IsSame(ctx, expected.param_types, actual.param_types) &&
+         IsSame(ctx, expected.result_types, actual.result_types);
 }
 
-bool IsSame(Context& context,
-            const StackType& expected,
-            const StackType& actual) {
+bool IsSame(ValidCtx& ctx, const StackType& expected, const StackType& actual) {
   // One of the types is "any" (i.e. universal supertype or subtype), or the
   // value types are the same.
   return expected.is_any() || actual.is_any() ||
-         IsSame(context, expected.value_type(), actual.value_type());
+         IsSame(ctx, expected.value_type(), actual.value_type());
 }
 
-bool IsSame(Context& context, StackTypeSpan expected, StackTypeSpan actual) {
+bool IsSame(ValidCtx& ctx, StackTypeSpan expected, StackTypeSpan actual) {
   if (expected.size() != actual.size()) {
     return false;
   }
@@ -135,32 +133,32 @@ bool IsSame(Context& context, StackTypeSpan expected, StackTypeSpan actual) {
   for (auto eiter = expected.begin(), lend = expected.end(),
             aiter = actual.begin();
        eiter != lend; ++eiter, ++aiter) {
-    if (!IsSame(context, *eiter, *aiter)) {
+    if (!IsSame(ctx, *eiter, *aiter)) {
       return false;
     }
   }
   return true;
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::StorageType& expected,
             const binary::StorageType& actual) {
   if (expected.is_value_type() && actual.is_value_type()) {
-    return IsSame(context, expected.value_type(), actual.value_type());
+    return IsSame(ctx, expected.value_type(), actual.value_type());
   } else if (expected.is_packed_type() && actual.is_packed_type()) {
     return expected.packed_type().value() == actual.packed_type().value();
   }
   return false;
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::FieldType& expected,
             const binary::FieldType& actual) {
-  return IsSame(context, expected.type, actual.type) &&
+  return IsSame(ctx, expected.type, actual.type) &&
          expected.mut.value() == actual.mut.value();
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::FieldTypeList& expected,
             const binary::FieldTypeList& actual) {
   if (expected.size() != actual.size()) {
@@ -170,41 +168,41 @@ bool IsSame(Context& context,
   for (auto eiter = expected.begin(), lend = expected.end(),
             aiter = actual.begin();
        eiter != lend; ++eiter, ++aiter) {
-    if (!IsSame(context, *eiter, *aiter)) {
+    if (!IsSame(ctx, *eiter, *aiter)) {
       return false;
     }
   }
   return true;
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::StructType& expected,
             const binary::StructType& actual) {
-  return IsSame(context, expected.fields, actual.fields);
+  return IsSame(ctx, expected.fields, actual.fields);
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::ArrayType& expected,
             const binary::ArrayType& actual) {
-  return IsSame(context, expected.field, actual.field);
+  return IsSame(ctx, expected.field, actual.field);
 }
 
-bool IsSame(Context& context,
+bool IsSame(ValidCtx& ctx,
             const binary::DefinedType& expected,
             const binary::DefinedType& actual) {
   if (expected.is_function_type() && actual.is_function_type()) {
-    return IsSame(context, expected.function_type(), actual.function_type());
+    return IsSame(ctx, expected.function_type(), actual.function_type());
   } else if (expected.is_struct_type() && actual.is_struct_type()) {
-    return IsSame(context, expected.struct_type(), actual.struct_type());
+    return IsSame(ctx, expected.struct_type(), actual.struct_type());
   } else if (expected.is_array_type() && actual.is_array_type()) {
-    return IsSame(context, expected.array_type(), actual.array_type());
+    return IsSame(ctx, expected.array_type(), actual.array_type());
   }
   return false;
 }
 
 /// IsMatch ///
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::HeapType& expected,
              const binary::HeapType& actual) {
   // `any` is a supertype of all types.
@@ -214,7 +212,7 @@ bool IsMatch(Context& context,
 
   // `func` is a supertype of all function types.
   if (expected.is_heap_kind(HeapKind::Func) && actual.is_index() &&
-      context.IsFunctionType(actual.index())) {
+      ctx.IsFunctionType(actual.index())) {
     return true;
   }
 
@@ -222,8 +220,8 @@ bool IsMatch(Context& context,
   if (expected.is_heap_kind(HeapKind::Eq)) {
     if (actual.is_heap_kind(HeapKind::I31)) {
       return true;
-    } else if (actual.is_index() && (context.IsStructType(actual.index()) ||
-                                     context.IsArrayType(actual.index()))) {
+    } else if (actual.is_index() && (ctx.IsStructType(actual.index()) ||
+                                     ctx.IsArrayType(actual.index()))) {
       return true;
     }
   }
@@ -238,65 +236,65 @@ bool IsMatch(Context& context,
     // Check whether heap types match, but make sure to handle recursive
     // structures. This is the same logic used in IsSame(HeapType, HeapType).
 
-    auto is_match_opt = context.match_types.Get(expected_index, actual_index);
+    auto is_match_opt = ctx.match_types.Get(expected_index, actual_index);
     if (is_match_opt) {
       return *is_match_opt;
     }
 
     // Assume that they match and check that everything still is valid.
-    context.match_types.Assume(expected_index, actual_index);
-    bool is_match = IsMatch(context, context.types[expected_index],
-                            context.types[actual_index]);
-    context.match_types.Resolve(expected_index, actual_index, is_match);
+    ctx.match_types.Assume(expected_index, actual_index);
+    bool is_match =
+        IsMatch(ctx, ctx.types[expected_index], ctx.types[actual_index]);
+    ctx.match_types.Resolve(expected_index, actual_index, is_match);
     return is_match;
   }
 
-  return IsSame(context, expected, actual);
+  return IsSame(ctx, expected, actual);
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::RefType& expected,
              const binary::RefType& actual) {
   // "ref null 0" is a supertype of "ref 0"
   if (expected.null == Null::No && actual.null == Null::Yes) {
     return false;
   }
-  return IsMatch(context, expected.heap_type.value(), actual.heap_type);
+  return IsMatch(ctx, expected.heap_type.value(), actual.heap_type);
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::ReferenceType& expected,
              const binary::ReferenceType& actual) {
   // Canonicalize in case one of the types is "ref null X" and the other is
   // "Xref".
-  return IsMatch(context, CanonicalizeToRefType(expected),
+  return IsMatch(ctx, CanonicalizeToRefType(expected),
                  CanonicalizeToRefType(actual));
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::Rtt& expected,
              const binary::Rtt& actual) {
   // Rtt's don't have any subtyping, aside from rtt <: any. However, unlike
   // IsSame(Rtt, Rtt) we consider two Rtts to match even if their depths don't
   // match. This is because for nearly all instructions, the depth is not used
   // in static validation.
-  return IsSame(context, expected.type, actual.type);
+  return IsSame(ctx, expected.type, actual.type);
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::ValueType& expected,
              const binary::ValueType& actual) {
   if (expected.is_numeric_type() && actual.is_numeric_type()) {
     return expected.numeric_type().value() == actual.numeric_type().value();
   } else if (expected.is_reference_type() && actual.is_reference_type()) {
-    return IsMatch(context, expected.reference_type(), actual.reference_type());
+    return IsMatch(ctx, expected.reference_type(), actual.reference_type());
   } else if (expected.is_rtt() && actual.is_rtt()) {
-    return IsMatch(context, expected.rtt(), actual.rtt());
+    return IsMatch(ctx, expected.rtt(), actual.rtt());
   }
   return false;
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::ValueTypeList& expected,
              const binary::ValueTypeList& actual) {
   if (expected.size() != actual.size()) {
@@ -306,23 +304,23 @@ bool IsMatch(Context& context,
   for (auto eiter = expected.begin(), lend = expected.end(),
             aiter = actual.begin();
        eiter != lend; ++eiter, ++aiter) {
-    if (!IsMatch(context, *eiter, *aiter)) {
+    if (!IsMatch(ctx, *eiter, *aiter)) {
       return false;
     }
   }
   return true;
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const StackType& expected,
              const StackType& actual) {
   // One of the types is "any" (i.e. universal supertype or subtype), or the
   // value types match.
   return expected.is_any() || actual.is_any() ||
-         IsMatch(context, expected.value_type(), actual.value_type());
+         IsMatch(ctx, expected.value_type(), actual.value_type());
 }
 
-bool IsMatch(Context& context, StackTypeSpan expected, StackTypeSpan actual) {
+bool IsMatch(ValidCtx& ctx, StackTypeSpan expected, StackTypeSpan actual) {
   if (expected.size() != actual.size()) {
     return false;
   }
@@ -330,35 +328,35 @@ bool IsMatch(Context& context, StackTypeSpan expected, StackTypeSpan actual) {
   for (auto eiter = expected.begin(), lend = expected.end(),
             aiter = actual.begin();
        eiter != lend; ++eiter, ++aiter) {
-    if (!IsMatch(context, *eiter, *aiter)) {
+    if (!IsMatch(ctx, *eiter, *aiter)) {
       return false;
     }
   }
   return true;
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::StorageType& expected,
              const binary::StorageType& actual) {
   if (expected.is_value_type() && actual.is_value_type()) {
-    return IsMatch(context, expected.value_type(), actual.value_type());
+    return IsMatch(ctx, expected.value_type(), actual.value_type());
   } else if (expected.is_packed_type() && actual.is_packed_type()) {
     return expected.packed_type().value() == actual.packed_type().value();
   }
   return false;
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::FieldType& expected,
              const binary::FieldType& actual) {
   // Only const fields are covariant.
   if (expected.mut == Mutability::Const && actual.mut == Mutability::Const) {
-    return IsMatch(context, expected.type, actual.type);
+    return IsMatch(ctx, expected.type, actual.type);
   }
-  return IsSame(context, expected, actual);
+  return IsSame(ctx, expected, actual);
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::FieldTypeList& expected,
              const binary::FieldTypeList& actual) {
   // A longer list of fields is a subtype of a shorter list, as long as the
@@ -370,41 +368,41 @@ bool IsMatch(Context& context,
   for (auto eiter = expected.begin(), lend = expected.end(),
             aiter = actual.begin();
        eiter != lend; ++eiter, ++aiter) {
-    if (!IsMatch(context, *eiter, *aiter)) {
+    if (!IsMatch(ctx, *eiter, *aiter)) {
       return false;
     }
   }
   return true;
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::FunctionType& expected,
              const binary::FunctionType& actual) {
   // Function types have no subtyping, so just check if they are equivalent.
-  return IsSame(context, expected, actual);
+  return IsSame(ctx, expected, actual);
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::StructType& expected,
              const binary::StructType& actual) {
-  return IsMatch(context, expected.fields, actual.fields);
+  return IsMatch(ctx, expected.fields, actual.fields);
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::ArrayType& expected,
              const binary::ArrayType& actual) {
-  return IsMatch(context, expected.field, actual.field);
+  return IsMatch(ctx, expected.field, actual.field);
 }
 
-bool IsMatch(Context& context,
+bool IsMatch(ValidCtx& ctx,
              const binary::DefinedType& expected,
              const binary::DefinedType& actual) {
   if (expected.is_function_type() && actual.is_function_type()) {
-    return IsSame(context, expected.function_type(), actual.function_type());
+    return IsSame(ctx, expected.function_type(), actual.function_type());
   } else if (expected.is_struct_type() && actual.is_struct_type()) {
-    return IsMatch(context, expected.struct_type(), actual.struct_type());
+    return IsMatch(ctx, expected.struct_type(), actual.struct_type());
   } else if (expected.is_array_type() && actual.is_array_type()) {
-    return IsMatch(context, expected.array_type(), actual.array_type());
+    return IsMatch(ctx, expected.array_type(), actual.array_type());
   }
   return false;
 }

--- a/src/valid/valid_ctx.cc
+++ b/src/valid/valid_ctx.cc
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-#include "wasp/valid/context.h"
+#include "wasp/valid/valid_ctx.h"
 
 #include <cassert>
 
@@ -30,34 +30,34 @@ Label::Label(LabelType label_type,
       type_stack_limit{type_stack_limit},
       unreachable{false} {}
 
-Context::Context(Errors& errors) : errors{&errors} {}
+ValidCtx::ValidCtx(Errors& errors) : errors{&errors} {}
 
-Context::Context(const Features& features, Errors& errors)
+ValidCtx::ValidCtx(const Features& features, Errors& errors)
     : features{features}, errors{&errors} {}
 
-Context::Context(const Context& other, Errors& errors) {
+ValidCtx::ValidCtx(const ValidCtx& other, Errors& errors) {
   *this = other;
   this->errors = &errors;
 }
 
-void Context::Reset() {
-  *this = Context{features, *errors};
+void ValidCtx::Reset() {
+  *this = ValidCtx{features, *errors};
 }
 
-bool Context::IsStackPolymorphic() const {
+bool ValidCtx::IsStackPolymorphic() const {
   assert(!label_stack.empty());
   return label_stack.back().unreachable;
 }
 
-bool Context::IsFunctionType(Index index) const {
+bool ValidCtx::IsFunctionType(Index index) const {
   return index < types.size() && types[index].is_function_type();
 }
 
-bool Context::IsStructType(Index index) const {
+bool ValidCtx::IsStructType(Index index) const {
   return index < types.size() && types[index].is_struct_type();
 }
 
-bool Context::IsArrayType(Index index) const {
+bool ValidCtx::IsArrayType(Index index) const {
   return index < types.size() && types[index].is_array_type();
 }
 

--- a/src/valid/validate_visitor.cc
+++ b/src/valid/validate_visitor.cc
@@ -21,68 +21,68 @@
 namespace wasp::valid {
 
 ValidateVisitor::ValidateVisitor(Features features, Errors& errors)
-    : context{features, errors}, features{features}, errors{errors} {}
+    : ctx{features, errors}, features{features}, errors{errors} {}
 
 auto ValidateVisitor::BeginTypeSection(binary::LazyTypeSection sec) -> Result {
-  return FailUnless(valid::BeginTypeSection(context, sec.count.value_or(0)));
+  return FailUnless(valid::BeginTypeSection(ctx, sec.count.value_or(0)));
 }
 
 auto ValidateVisitor::OnType(const At<binary::DefinedType>& defined_type)
     -> Result {
-  return FailUnless(Validate(context, defined_type));
+  return FailUnless(Validate(ctx, defined_type));
 }
 
 auto ValidateVisitor::OnImport(const At<binary::Import>& import) -> Result {
-  return FailUnless(Validate(context, import));
+  return FailUnless(Validate(ctx, import));
 }
 
 auto ValidateVisitor::OnFunction(const At<binary::Function>& function)
     -> Result {
-  return FailUnless(Validate(context, function));
+  return FailUnless(Validate(ctx, function));
 }
 
 auto ValidateVisitor::OnTable(const At<binary::Table>& table) -> Result {
-  return FailUnless(Validate(context, table));
+  return FailUnless(Validate(ctx, table));
 }
 
 auto ValidateVisitor::OnMemory(const At<binary::Memory>& memory) -> Result {
-  return FailUnless(Validate(context, memory));
+  return FailUnless(Validate(ctx, memory));
 }
 
 auto ValidateVisitor::OnGlobal(const At<binary::Global>& global) -> Result {
-  return FailUnless(Validate(context, global));
+  return FailUnless(Validate(ctx, global));
 }
 
 auto ValidateVisitor::OnExport(const At<binary::Export>& export_) -> Result {
-  return FailUnless(Validate(context, export_));
+  return FailUnless(Validate(ctx, export_));
 }
 
 auto ValidateVisitor::OnStart(const At<binary::Start>& start) -> Result {
-  return FailUnless(Validate(context, start));
+  return FailUnless(Validate(ctx, start));
 }
 
 auto ValidateVisitor::OnElement(const At<binary::ElementSegment>& segment)
     -> Result {
-  return FailUnless(Validate(context, segment));
+  return FailUnless(Validate(ctx, segment));
 }
 
 auto ValidateVisitor::OnDataCount(const At<binary::DataCount>& data_count)
     -> Result {
-  return FailUnless(Validate(context, data_count));
+  return FailUnless(Validate(ctx, data_count));
 }
 
 auto ValidateVisitor::BeginCode(const At<binary::Code>& code) -> Result {
-  return FailUnless(valid::BeginCode(context, code.loc()) &&
-                    Validate(context, code->locals, RequireDefaultable::Yes));
+  return FailUnless(valid::BeginCode(ctx, code.loc()) &&
+                    Validate(ctx, code->locals, RequireDefaultable::Yes));
 }
 
 auto ValidateVisitor::OnInstruction(const At<binary::Instruction>& instruction)
     -> Result {
-  return FailUnless(Validate(context, instruction));
+  return FailUnless(Validate(ctx, instruction));
 }
 
 auto ValidateVisitor::OnData(const At<binary::DataSegment>& segment) -> Result {
-  return FailUnless(Validate(context, segment));
+  return FailUnless(Validate(ctx, segment));
 }
 
 auto ValidateVisitor::FailUnless(bool b) -> Result {

--- a/test/binary/lazy_expression_test.cc
+++ b/test/binary/lazy_expression_test.cc
@@ -18,7 +18,7 @@
 
 #include "gtest/gtest.h"
 #include "test/test_utils.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 
 using namespace ::wasp;
 using namespace ::wasp::binary;
@@ -26,8 +26,8 @@ using namespace ::wasp::test;
 
 TEST(BinaryLazyExprTest, Basic) {
   TestErrors errors;
-  Context context{errors};
-  auto expr = ReadExpression("\x00"_su8, context);
+  ReadCtx ctx{errors};
+  auto expr = ReadExpression("\x00"_su8, ctx);
   auto it = expr.begin(), end = expr.end();
   EXPECT_EQ((At{"\x00"_su8, Instruction{At{"\x00"_su8, Opcode::Unreachable}}}),
             *it++);
@@ -36,8 +36,8 @@ TEST(BinaryLazyExprTest, Basic) {
 
 TEST(BinaryLazyExprTest, Multiple) {
   TestErrors errors;
-  Context context{errors};
-  auto expr = ReadExpression("\x01\x01"_su8, context);
+  ReadCtx ctx{errors};
+  auto expr = ReadExpression("\x01\x01"_su8, ctx);
   auto it = expr.begin(), end = expr.end();
   EXPECT_EQ((At{"\x01"_su8, Instruction{At{"\x01"_su8, Opcode::Nop}}}), *it++);
   ASSERT_NE(end, it);
@@ -47,11 +47,11 @@ TEST(BinaryLazyExprTest, Multiple) {
 
 TEST(BinaryLazyExprTest, SimpleFunction) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   // local.get 0
   // local.get 1
   // i32.add
-  auto expr = ReadExpression("\x20\x00\x20\x01\x6a"_su8, context);
+  auto expr = ReadExpression("\x20\x00\x20\x01\x6a"_su8, ctx);
   auto it = expr.begin(), end = expr.end();
   EXPECT_EQ((At{"\x20\x00"_su8, Instruction{At{"\x20"_su8, Opcode::LocalGet},
                                             At{"\x00"_su8, Index{0}}}}),

--- a/test/binary/lazy_linking_section_test.cc
+++ b/test/binary/lazy_linking_section_test.cc
@@ -18,7 +18,7 @@
 #include "test/test_utils.h"
 #include "wasp/binary/linking_section/sections.h"
 #include "wasp/binary/linking_section/types.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 
 using namespace ::wasp;
 using namespace ::wasp::binary;
@@ -41,14 +41,14 @@ void ExpectSubsection(const std::vector<T>& expected, LazySection<T>& sec) {
 
 TEST(BinaryLinkingSectionTest, LinkingSection) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadLinkingSection(
       "\x02"                // Linking version.
       "\x05\x05zzzzz"       // Segment info
       "\x06\x05zzzzz"       // Init functions
       "\x07\x05zzzzz"       // Comdat info
       "\x08\x05zzzzz"_su8,  // Symbol table
-      context);
+      ctx);
 
   auto it = sec.subsections.begin();
   auto end = sec.subsections.end();
@@ -79,13 +79,13 @@ TEST(BinaryLinkingSectionTest, LinkingSection) {
 
 TEST(BinaryLinkingSectionTest, SegmentInfoSubsection) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadSegmentInfoSubsection(
       "\x03"
       "\x01X\x01\x02"
       "\x01Y\x03\x04"
       "\x01Z\x05\x06"_su8,
-      context);
+      ctx);
 
   ExpectSubsection({SegmentInfo{At{"\x01X"_su8, "X"_sv}, At{"\x01"_su8, u32{1}},
                                 At{"\x02"_su8, u32{2}}},
@@ -99,12 +99,12 @@ TEST(BinaryLinkingSectionTest, SegmentInfoSubsection) {
 
 TEST(BinaryLinkingSectionTest, InitFunctionsSubsection) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadInitFunctionsSubsection(
       "\x02"
       "\x01\x02"
       "\x03\x04"_su8,
-      context);
+      ctx);
 
   ExpectSubsection(
       {InitFunction{At{"\x01"_su8, u32{1}}, At{"\x02"_su8, Index{2}}},
@@ -115,12 +115,12 @@ TEST(BinaryLinkingSectionTest, InitFunctionsSubsection) {
 
 TEST(BinaryLinkingSectionTest, ComdatSubsection) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadComdatSubsection(
       "\x02"
       "\x01X\0\x01\x03\x04"
       "\x01Y\0\x00"_su8,
-      context);
+      ctx);
 
   ExpectSubsection(
       {Comdat{At{"\x01X"_su8, "X"_sv},
@@ -135,13 +135,13 @@ TEST(BinaryLinkingSectionTest, ComdatSubsection) {
 
 TEST(BinaryLinkingSectionTest, SymbolTableSubsection) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadSymbolTableSubsection(
       "\x03"
       "\x00\x40\x00\x03YYY"
       "\x01\x00\x03ZZZ\x00\x00\x00"
       "\x03\x00\x00"_su8,
-      context);
+      ctx);
 
   using SI = SymbolInfo;
   using F = SymbolInfo::Flags;

--- a/test/binary/lazy_name_section_test.cc
+++ b/test/binary/lazy_name_section_test.cc
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 #include "test/test_utils.h"
 #include "wasp/binary/name_section/sections.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 
 using namespace ::wasp;
 using namespace ::wasp::binary;
@@ -40,13 +40,13 @@ void ExpectSubsection(const std::vector<T>& expected, LazySection<T>& sec) {
 
 TEST(BinaryLazyNameSectionTest, NameSection) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadNameSection(
       "\x00\x02\x01m"                              // Module name = "m"
       "\x01\x03\x02\x01g"                          // Function names: 2 => "g"
       "\x02\x0a\x03\x02\x04\x02g4\x05\x02g5"_su8,  // Local names: function 3
                                                    //   4 => "g4", 5 => "g5"
-      context);
+      ctx);
 
   auto it = sec.begin();
 
@@ -73,19 +73,19 @@ TEST(BinaryLazyNameSectionTest, NameSection) {
 
 TEST(BinaryLazyNameSectionTest, ModuleNameSubsection) {
   TestErrors errors;
-  Context context{errors};
-  auto name = ReadModuleNameSubsection("\x04name"_su8, context);
+  ReadCtx ctx{errors};
+  auto name = ReadModuleNameSubsection("\x04name"_su8, ctx);
   EXPECT_EQ("name", name);
   ExpectNoErrors(errors);
 }
 
 TEST(BinaryLazyNameSectionTest, FunctionNamesSubsection) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadFunctionNamesSubsection(
       "\x02\x03\x05three\x05\x04"
       "five"_su8,
-      context);
+      ctx);
 
   ExpectSubsection(
       {NameAssoc{At{"\x03"_su8, Index{3}}, At{"\x05three"_su8, "three"_sv}},
@@ -98,13 +98,13 @@ TEST(BinaryLazyNameSectionTest, FunctionNamesSubsection) {
 
 TEST(BinaryLazyNameSectionTest, LocalNamesSubsection) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadLocalNamesSubsection(
       "\x02"
       "\x02\x02\x01\x04ichi\x03\x03san"
       "\x04\x01\x05\x05"
       "cinco"_su8,
-      context);
+      ctx);
 
   ExpectSubsection(
       {IndirectNameAssoc{

--- a/test/binary/lazy_relocation_section_test.cc
+++ b/test/binary/lazy_relocation_section_test.cc
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 #include "test/test_utils.h"
 #include "wasp/binary/linking_section/sections.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 
 using namespace ::wasp;
 using namespace ::wasp::binary;
@@ -25,13 +25,13 @@ using namespace ::wasp::test;
 
 TEST(BinaryRelocationTest, Basic) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadRelocationSection(
       "\x01\x03"  // Section index = 1, 3 relocations.
       "\x01\x02\x03"
       "\x04\x05\x06\x07"
       "\x08\x09\x0a\x0b"_su8,
-      context);
+      ctx);
 
   EXPECT_EQ(Index{1}, sec.section_index);
   EXPECT_EQ(Index{3}, sec.count);

--- a/test/binary/lazy_section_test.cc
+++ b/test/binary/lazy_section_test.cc
@@ -20,7 +20,7 @@
 #include "test/binary/constants.h"
 #include "test/binary/test_utils.h"
 #include "test/test_utils.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 #include "wasp/binary/sections.h"
 
 using namespace ::wasp;
@@ -45,12 +45,12 @@ void ExpectSection(const std::vector<T>& expected, LazySection<T>& sec) {
 
 TEST(BinaryLazySectionTest, Type) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadTypeSection(
       "\x02"                           // Count.
       "\x60\x00\x00"                   // (param) (result)
       "\x60\x02\x7f\x7f\x01\x7f"_su8,  // (param i32 i32) (result i32)
-      context);
+      ctx);
 
   ExpectSection(
       {
@@ -66,12 +66,12 @@ TEST(BinaryLazySectionTest, Type) {
 
 TEST(BinaryLazySectionTest, Import) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadImportSection(
       "\x02"                             // Count.
       "\x01w\x01x\x00\x02"               // (import "w" "x" (func 2))
       "\x01y\x01z\x02\x01\x01\x02"_su8,  // (import "y" "z" (memory 1 2))
-      context);
+      ctx);
 
   ExpectSection(
       {
@@ -90,11 +90,11 @@ TEST(BinaryLazySectionTest, Import) {
 
 TEST(BinaryLazySectionTest, Function) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadFunctionSection(
       "\x03"                   // Count.
       "\x02\x80\x01\x02"_su8,  // 2, 128, 2
-      context);
+      ctx);
 
   ExpectSection(
       {
@@ -108,13 +108,13 @@ TEST(BinaryLazySectionTest, Function) {
 
 TEST(BinaryLazySectionTest, Table) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadTableSection(
       "\x03"                  // Count.
       "\x70\x00\x01"          // (table 1 funcref)
       "\x70\x01\x00\x80\x01"  // (table 0 128 funcref)
       "\x70\x00\x00"_su8,     // (table 0 funcref)
-      context);
+      ctx);
 
   ExpectSection(
       {
@@ -141,13 +141,13 @@ TEST(BinaryLazySectionTest, Table) {
 
 TEST(BinaryLazySectionTest, Memory) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadMemorySection(
       "\x03"              // Count.
       "\x00\x01"          // (memory 1)
       "\x01\x00\x80\x01"  // (memory 0 128)
       "\x00\x00"_su8,     // (memory 0)
-      context);
+      ctx);
 
   ExpectSection(
       {
@@ -171,12 +171,12 @@ TEST(BinaryLazySectionTest, Memory) {
 
 TEST(BinaryLazySectionTest, Global) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadGlobalSection(
       "\x02"                       // Count.
       "\x7f\x01\x41\x00\x0b"       // (global (mut i32) (i32.const 0))
       "\x7e\x00\x42\x01\x0b"_su8,  // (global i64 (i64.const 1))
-      context);
+      ctx);
 
   ExpectSection(
       {
@@ -203,13 +203,13 @@ TEST(BinaryLazySectionTest, Global) {
 
 TEST(BinaryLazySectionTest, Export) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadExportSection(
       "\x03"                    // Count.
       "\x03one\x00\x01"         // (export "one" (func 1))
       "\x03two\x02\x02"         // (export "two" (memory 2))
       "\x05three\x03\x02"_su8,  // (export "three" (global 2))
-      context);
+      ctx);
 
   ExpectSection(
       {
@@ -226,8 +226,8 @@ TEST(BinaryLazySectionTest, Export) {
 
 TEST(BinaryLazySectionTest, Start) {
   TestErrors errors;
-  Context context{errors};
-  auto sec = ReadStartSection("\x03"_su8, context);
+  ReadCtx ctx{errors};
+  auto sec = ReadStartSection("\x03"_su8, ctx);
 
   EXPECT_EQ((Start{At{"\x03"_su8, Index{3}}}), sec);
   ExpectNoErrors(errors);
@@ -235,12 +235,12 @@ TEST(BinaryLazySectionTest, Start) {
 
 TEST(BinaryLazySectionTest, Element) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadElementSection(
       "\x02"                           // Count.
       "\x00\x41\x00\x0b\x02\x00\x01"   // (elem (offset i32.const 0) 0 1)
       "\x00\x41\x02\x0b\x01\x03"_su8,  // (elem (offset i32.const 2) 3)
-      context);
+      ctx);
 
   ExpectSection(
       {
@@ -268,12 +268,12 @@ TEST(BinaryLazySectionTest, Element) {
 
 TEST(BinaryLazySectionTest, Code) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadCodeSection(
       "\x02"                           // Count.
       "\x02\x00\x0b"                   // (func)
       "\x05\x01\x01\x7f\x6a\x0b"_su8,  // (func (local i32) i32.add)
-      context);
+      ctx);
 
   ExpectSection(
       {
@@ -288,13 +288,13 @@ TEST(BinaryLazySectionTest, Code) {
 
 TEST(BinaryLazySectionTest, Data) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   auto sec = ReadDataSection(
       "\x03"                          // Count.
       "\x00\x41\x00\x0b\x02hi"        // (data (offset i32.const 0) "hi")
       "\x00\x41\x02\x0b\x03see"       // (data (offset i32.const 2) "see")
       "\x00\x41\x05\x0b\x03you"_su8,  // (data (offset i32.const 5) "you")
-      context);
+      ctx);
 
   ExpectSection(
       {
@@ -328,8 +328,8 @@ TEST(BinaryLazySectionTest, Data) {
 
 TEST(BinaryLazySectionTest, DataCount) {
   TestErrors errors;
-  Context context{errors};
-  auto sec = ReadDataCountSection("\x03"_su8, context);
+  ReadCtx ctx{errors};
+  auto sec = ReadDataCountSection("\x03"_su8, ctx);
 
   EXPECT_EQ((DataCount{At{"\x03"_su8, Index{3}}}), sec);
   ExpectNoErrors(errors);

--- a/test/binary/lazy_sequence_test.cc
+++ b/test/binary/lazy_sequence_test.cc
@@ -20,7 +20,7 @@
 #include "test/test_utils.h"
 #include "wasp/base/errors_nop.h"
 #include "wasp/binary/read.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 
 using namespace ::wasp;
 using namespace ::wasp::binary;
@@ -28,8 +28,8 @@ using namespace ::wasp::test;
 
 TEST(BinaryLazySequenceTest, Basic) {
   ErrorsNop errors;
-  Context context{errors};
-  LazySequence<u32> seq{"\x01\x80\x02\x00\x80\x80\x01"_su8, context};
+  ReadCtx ctx{errors};
+  LazySequence<u32> seq{"\x01\x80\x02\x00\x80\x80\x01"_su8, ctx};
   auto it = seq.begin();
 
   EXPECT_EQ(1u, *it++);
@@ -47,17 +47,17 @@ TEST(BinaryLazySequenceTest, Basic) {
 
 TEST(BinaryLazySequenceTest, Empty) {
   ErrorsNop errors;
-  Context context{errors};
-  LazySequence<u8> seq{""_su8, context};
+  ReadCtx ctx{errors};
+  LazySequence<u8> seq{""_su8, ctx};
 
   EXPECT_EQ(seq.begin(), seq.end());
 }
 
 TEST(BinaryLazySequenceTest, Error) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   const auto data = "\x40\x30\x80"_su8;
-  LazySequence<s32> seq{data, context};
+  LazySequence<s32> seq{data, ctx};
 
   auto it = seq.begin();
 
@@ -72,9 +72,9 @@ TEST(BinaryLazySequenceTest, Error) {
 
 TEST(BinaryLazySequenceTest, ExpectedCount_Match) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   const auto data = "\x00\x01"_su8;
-  LazySequence<s32> seq{data, 2, "MySequence", context};
+  LazySequence<s32> seq{data, 2, "MySequence", ctx};
 
   auto it = seq.begin();
   it++;
@@ -84,9 +84,9 @@ TEST(BinaryLazySequenceTest, ExpectedCount_Match) {
 
 TEST(BinaryLazySequenceTest, ExpectedCount_ActualLess) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   const auto data = "\x00"_su8;
-  LazySequence<s32> seq{data, 2, "MySequence", context};
+  LazySequence<s32> seq{data, 2, "MySequence", ctx};
 
   auto it = seq.begin();
   it++;
@@ -96,9 +96,9 @@ TEST(BinaryLazySequenceTest, ExpectedCount_ActualLess) {
 
 TEST(BinaryLazySequenceTest, ExpectedCount_ActualMore) {
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
   const auto data = "\x00\x01\x02\x03"_su8;
-  LazySequence<s32> seq{data, 2, "MySequence", context};
+  LazySequence<s32> seq{data, 2, "MySequence", ctx};
 
   auto it = seq.begin();
   it++;

--- a/test/binary/read_linking_test.cc
+++ b/test/binary/read_linking_test.cc
@@ -19,7 +19,7 @@
 #include "test/test_utils.h"
 #include "wasp/binary/linking_section/encoding.h"
 #include "wasp/binary/linking_section/read.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 
 using namespace ::wasp;
 using namespace ::wasp::binary;
@@ -31,7 +31,7 @@ class BinaryReadLinkingTest : public ::testing::Test {
  protected:
   template <typename Func, typename T, typename... Args>
   void OK(Func&& func, const T& expected, SpanU8 data, Args&&... args) {
-    auto actual = func(&data, context, std::forward<Args>(args)...);
+    auto actual = func(&data, ctx, std::forward<Args>(args)...);
     ExpectNoErrors(errors);
     EXPECT_EQ(0u, data.size());
     EXPECT_NE(nullptr, actual->loc().data());
@@ -40,7 +40,7 @@ class BinaryReadLinkingTest : public ::testing::Test {
   }
 
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
 };
 
 TEST_F(BinaryReadLinkingTest, Comdat) {

--- a/test/binary/read_module_test.cc
+++ b/test/binary/read_module_test.cc
@@ -20,7 +20,7 @@
 #include "test/binary/constants.h"
 #include "test/binary/test_utils.h"
 #include "test/test_utils.h"
-#include "wasp/binary/read/context.h"
+#include "wasp/binary/read/read_ctx.h"
 
 using namespace ::wasp;
 using namespace ::wasp::binary;
@@ -30,21 +30,21 @@ using namespace ::wasp::binary::test;
 class BinaryReadModuleTest : public ::testing::Test {
  protected:
   void OK(const Module& expected, SpanU8 data) {
-    auto actual = ReadModule(data, context);
+    auto actual = ReadModule(data, ctx);
     ExpectNoErrors(errors);
     ASSERT_TRUE(actual.has_value());
     EXPECT_EQ(expected, actual.value());
   }
 
   void Fail(const ExpectedError& error, SpanU8 data) {
-    auto actual = ReadModule(data, context);
+    auto actual = ReadModule(data, ctx);
     EXPECT_FALSE(actual.has_value());
     ExpectError(error, errors, data);
     errors.Clear();
   }
 
   TestErrors errors;
-  Context context{errors};
+  ReadCtx ctx{errors};
 };
 
 TEST_F(BinaryReadModuleTest, EmptyModule) {

--- a/test/convert/to_binary_test.cc
+++ b/test/convert/to_binary_test.cc
@@ -32,7 +32,7 @@ class ConvertToBinaryTest : public ::testing::Test {
  protected:
   template <typename B, typename T, typename... Args>
   void OK(const B& expected, const T& input, Args&&... args) {
-    auto actual = ToBinary(context, input, std::forward<Args>(args)...);
+    auto actual = ToBinary(ctx, input, std::forward<Args>(args)...);
     EXPECT_EQ(expected, actual);
   }
 
@@ -41,10 +41,10 @@ class ConvertToBinaryTest : public ::testing::Test {
               const B& expected,
               const T& input,
               Args&&... args) {
-    EXPECT_EQ(expected, func(context, input, std::forward<Args>(args)...));
+    EXPECT_EQ(expected, func(ctx, input, std::forward<Args>(args)...));
   }
 
-  Context context;
+  BinCtx ctx;
 };
 
 const SpanU8 loc1 = "A"_su8;
@@ -1005,9 +1005,9 @@ TEST_F(ConvertToBinaryTest, OpcodeAlignment) {
       {Opcode::V128Store, 4},
   };
   for (auto& test : tests) {
-    Context context;
+    BinCtx ctx;
     auto result = ToBinary(
-        context, text::Instruction{test.opcode, text::MemArgImmediate{}});
+        ctx, text::Instruction{test.opcode, text::MemArgImmediate{}});
     EXPECT_EQ(test.expected_align_log2,
               result->mem_arg_immediate()->align_log2);
   }
@@ -1324,7 +1324,7 @@ TEST_F(ConvertToBinaryTest, Module) {
 }
 
 TEST_F(ConvertToBinaryTest, DataCount_BulkMemory) {
-  context.features.enable_bulk_memory();
+  ctx.features.enable_bulk_memory();
 
   OK(At{loc1,
         binary::Module{

--- a/test/convert/to_text_test.cc
+++ b/test/convert/to_text_test.cc
@@ -30,8 +30,8 @@ namespace {
 
 template <typename T, typename B, typename... Args>
 void OK(const T& expected, const B& input, Args&&... args) {
-  TextContext context;
-  auto actual = ToText(context, input, std::forward<Args>(args)...);
+  TextCtx ctx;
+  auto actual = ToText(ctx, input, std::forward<Args>(args)...);
   EXPECT_EQ(expected, actual);
 }
 

--- a/test/text/write_test.cc
+++ b/test/text/write_test.cc
@@ -36,10 +36,10 @@ namespace {
 
 template <typename T, typename... Args>
 void ExpectWrite(string_view expected, const T& value, Args&&... args) {
-  WriteContext context;
+  WriteCtx ctx;
   std::string result(expected.size(), 'X');
   auto iter =
-      wasp::text::Write(context, value, std::forward<Args>(args)...,
+      wasp::text::Write(ctx, value, std::forward<Args>(args)...,
                         MakeClampedIterator(result.begin(), result.end()));
   EXPECT_FALSE(iter.overflow());
   EXPECT_EQ(iter.base(), result.end());

--- a/test/valid/validate_code_test.cc
+++ b/test/valid/validate_code_test.cc
@@ -18,7 +18,7 @@
 #include "test/binary/constants.h"
 #include "test/valid/test_utils.h"
 #include "wasp/base/features.h"
-#include "wasp/valid/context.h"
+#include "wasp/valid/valid_ctx.h"
 #include "wasp/valid/validate.h"
 
 using namespace ::wasp;
@@ -29,41 +29,41 @@ using namespace ::wasp::valid::test;
 
 TEST(ValidateCodeTest, BeginCode) {
   TestErrors errors;
-  Context context{errors};
-  context.types.push_back(DefinedType{FunctionType{}});
-  context.defined_type_count = 1;
-  context.functions.push_back(Function{0});
-  EXPECT_TRUE(BeginCode(context, Location{}));
+  ValidCtx ctx{errors};
+  ctx.types.push_back(DefinedType{FunctionType{}});
+  ctx.defined_type_count = 1;
+  ctx.functions.push_back(Function{0});
+  EXPECT_TRUE(BeginCode(ctx, Location{}));
 }
 
 TEST(ValidateCodeTest, BeginCode_CodeIndexOOB) {
   TestErrors errors;
-  Context context{errors};
-  context.types.push_back(DefinedType{FunctionType{}});
-  context.functions.push_back(Function{0});
-  context.code_count = 1;
-  EXPECT_FALSE(BeginCode(context, Location{}));
+  ValidCtx ctx{errors};
+  ctx.types.push_back(DefinedType{FunctionType{}});
+  ctx.functions.push_back(Function{0});
+  ctx.code_count = 1;
+  EXPECT_FALSE(BeginCode(ctx, Location{}));
 }
 
 TEST(ValidateCodeTest, BeginCode_TypeIndexOOB) {
   TestErrors errors;
-  Context context{errors};
-  context.types.push_back(DefinedType{FunctionType{}});
-  context.functions.push_back(Function{1});
-  EXPECT_FALSE(BeginCode(context, Location{}));
+  ValidCtx ctx{errors};
+  ctx.types.push_back(DefinedType{FunctionType{}});
+  ctx.functions.push_back(Function{1});
+  EXPECT_FALSE(BeginCode(ctx, Location{}));
 }
 
 TEST(ValidateCodeTest, BeginCode_NonFunctionType) {
   TestErrors errors;
-  Context context{errors};
-  context.types.push_back(DefinedType{StructType{}});
-  context.defined_type_count = 1;
-  context.functions.push_back(Function{0});
-  EXPECT_FALSE(BeginCode(context, Location{}));
+  ValidCtx ctx{errors};
+  ctx.types.push_back(DefinedType{StructType{}});
+  ctx.defined_type_count = 1;
+  ctx.functions.push_back(Function{0});
+  EXPECT_FALSE(BeginCode(ctx, Location{}));
 }
 
 TEST(ValidateCodeTest, Locals) {
   TestErrors errors;
-  Context context{errors};
-  EXPECT_TRUE(Validate(context, Locals{10, VT_I32}, RequireDefaultable::Yes));
+  ValidCtx ctx{errors};
+  EXPECT_TRUE(Validate(ctx, Locals{10, VT_I32}, RequireDefaultable::Yes));
 }


### PR DESCRIPTION
The following classes are renamed:

wasp::binary::{Context -> ReadCtx}
wasp::convert::{Context -> BinCtx}
wasp::convert::{TextContext -> TextCtx}
wasp::text::{Context -> ReadCtx}
wasp::text::{ResolveContext -> ResolveCtx}
wasp::text::{WriteContext -> WriteCtx}
wasp::valid::{Context -> ValidCtx}

In addition, all variables are renamed from `context` -> `ctx`.