### PR TITLE
Fix crash when validating invalid type index

### DIFF
--- a/include/wasp/valid/validate.h
+++ b/include/wasp/valid/validate.h
@@ -30,6 +30,7 @@ enum class RequireDefaultable {
 struct ValidCtx;
 
 bool BeginTypeSection(ValidCtx&, Index type_count);
+bool EndTypeSection(ValidCtx&);
 bool BeginCode(ValidCtx&, Location loc);
 
 bool CheckDefaultable(ValidCtx&,
@@ -71,6 +72,12 @@ bool ValidateIndex(ValidCtx&,
                    const At<Index>& index,
                    Index max,
                    string_view desc);
+bool ValidateTypeIndex(ValidCtx&, const At<Index>& index);
+bool ValidateFunctionIndex(ValidCtx&, const At<Index>& index);
+bool ValidateMemoryIndex(ValidCtx&, const At<Index>& index);
+bool ValidateTableIndex(ValidCtx&, const At<Index>& index);
+bool ValidateGlobalIndex(ValidCtx&, const At<Index>& index);
+bool ValidateEventIndex(ValidCtx&, const At<Index>& index);
 bool Validate(ValidCtx&, const At<binary::Instruction>&);
 bool Validate(ValidCtx&, const At<Limits>&, Index max);
 bool Validate(ValidCtx&, const At<binary::Locals>&, RequireDefaultable);

--- a/include/wasp/valid/validate_visitor.h
+++ b/include/wasp/valid/validate_visitor.h
@@ -34,6 +34,7 @@ struct ValidateVisitor : binary::visit::Visitor {
 
   auto BeginTypeSection(binary::LazyTypeSection) -> Result;
   auto OnType(const At<binary::DefinedType>&) -> Result;
+  auto EndTypeSection(binary::LazyTypeSection) -> Result;
   auto OnImport(const At<binary::Import>&) -> Result;
   auto OnFunction(const At<binary::Function>&) -> Result;
   auto OnTable(const At<binary::Table>&) -> Result;

--- a/src/valid/validate_visitor.cc
+++ b/src/valid/validate_visitor.cc
@@ -32,6 +32,10 @@ auto ValidateVisitor::OnType(const At<binary::DefinedType>& defined_type)
   return FailUnless(Validate(ctx, defined_type));
 }
 
+auto ValidateVisitor::EndTypeSection(binary::LazyTypeSection sec) -> Result {
+  return FailUnless(valid::EndTypeSection(ctx));
+}
+
 auto ValidateVisitor::OnImport(const At<binary::Import>& import) -> Result {
   return FailUnless(Validate(ctx, import));
 }

--- a/test/valid/validate_test.cc
+++ b/test/valid/validate_test.cc
@@ -1322,3 +1322,22 @@ TEST(ValidateTest, Module) {
 
   EXPECT_TRUE(Validate(ctx, module));
 }
+
+TEST(ValidateTest, TypeIndexOOBAfterTypeSection) {
+  TestErrors errors;
+  ValidCtx ctx{errors};
+
+  // Declare two types, but don't define them. This could happen if the types
+  // aren't actually defined, or if they could not be parsed.
+  BeginTypeSection(ctx, 2);
+  EndTypeSection(ctx);
+
+  // Make sure that anything that references the type section will correctly
+  // fail to validate.
+  EXPECT_FALSE(Validate(
+      ctx, Import{"", "", EventType{EventAttribute::Exception, Index{0}}}));
+
+  EXPECT_FALSE(Validate(ctx, Function{0}));
+
+  EXPECT_FALSE(Validate(ctx, VT_Ref0));
+}


### PR DESCRIPTION
As of the GC proposal, it is possible to have types that reference a
type index that has not yet been defined (i.e. recursive types). To
handle this, the validator will use the number of types declared
(`ValidCtx::defined_type_count`) in the type section to determine
whether the type index is valid.

The number of types that is actually defined (`ValidCtx::types::size()`)
may not match the number that was declared (e.g. if the type could not
be parsed, or is omitted). If this happens then accessing
`ValidCtx::types` with that index will crash.

This change updates `defined_type_count` at the end of the type section
to match the number of types that was actually defined. This way we can
always use `defined_type_count` and it will be consistent with the
number of defined types.

Also, we've added a few helper functions to make validating indexes
clearer: `ValidateTypeIndex`, `ValidateFunctionIndex`,
`ValidateMemoryIndex`, `ValidateTableIndex`, `ValidateGlobalIndex`,
`ValidateEventIndex`.