### PR TITLE
Read select without immediate

### DIFF
--- a/src/text/read.cc
+++ b/src/text/read.cc
@@ -1716,17 +1716,18 @@ auto ReadPlainInstruction(Tokenizer& tokenizer, ReadCtx& ctx)
       WASP_TRY(CheckOpcodeEnabled(token, ctx));
       tokenizer.Read();
       At<Opcode> opcode = token.opcode();
-      At<ValueTypeList> immediate;
       if (ctx.features.reference_types_enabled()) {
         LocationGuard immediate_guard{tokenizer};
         WASP_TRY_READ(value_type_list, ReadResultList(tokenizer, ctx));
-        immediate = At{immediate_guard.loc(), value_type_list};
+
         if (!value_type_list.empty()) {
           // Typed select has a different opcode.
-          opcode = At{opcode.loc(), Opcode::SelectT};
+          return At{guard.loc(),
+                    Instruction{At{opcode.loc(), Opcode::SelectT},
+                                At{immediate_guard.loc(), value_type_list}}};
         }
       }
-      return At{guard.loc(), Instruction{opcode, immediate}};
+      return At{guard.loc(), Instruction{opcode}};
     }
 
     case TokenType::SimdConstInstr: {

--- a/test/text/read_test.cc
+++ b/test/text/read_test.cc
@@ -964,18 +964,14 @@ TEST_F(TextReadTest, PlainInstruction_MemArg) {
 }
 
 TEST_F(TextReadTest, PlainInstruction_Select) {
-  OK(ReadPlainInstruction,
-     I{At{"select"_su8, O::Select}, At{""_su8, SelectImmediate{}}},
-     "select"_su8);
+  OK(ReadPlainInstruction, I{At{"select"_su8, O::Select}}, "select"_su8);
 }
 
 TEST_F(TextReadTest, PlainInstruction_Select_reference_types) {
   ctx.features.enable_reference_types();
 
   // select w/o types
-  OK(ReadPlainInstruction,
-     I{At{"select"_su8, O::Select}, At{""_su8, SelectImmediate{}}},
-     "select"_su8);
+  OK(ReadPlainInstruction, I{At{"select"_su8, O::Select}}, "select"_su8);
 
   // select w/ one type
   OK(ReadPlainInstruction,


### PR DESCRIPTION
The reference types proposal adds a new select instruction which can
take a list of return types (`SelectImmediate`) as an immediate. This
immediate should only be used with the new select instruction (opcode
`0x1c`), not the old instruction (opcode `0x1b`).