### PR TITLE
Fix `let`: reading binary, writing text

### DIFF
--- a/include/wasp/text/write.h
+++ b/include/wasp/text/write.h
@@ -567,8 +567,8 @@ Iterator WriteWithNewlines(WriteCtx& ctx,
 
     out = Write(ctx, instr, out);
 
-    if (instr->has_block_immediate() || opcode == Opcode::Else ||
-        opcode == Opcode::Catch) {
+    if (instr->has_block_immediate() || instr->has_let_immediate() ||
+        opcode == Opcode::Else || opcode == Opcode::Catch) {
       ctx.Indent();
     }
     ctx.Newline();

--- a/src/binary/read.cc
+++ b/src/binary/read.cc
@@ -1227,6 +1227,7 @@ OptAt<Instruction> Read(SpanU8* data, ReadCtx& ctx, Tag<Instruction>) {
     // Let immediate.
     case Opcode::Let: {
       WASP_TRY_READ(immediate, Read<LetImmediate>(data, ctx));
+      ctx.open_blocks.push_back(opcode);
       return At{guard.range(data), Instruction{opcode, immediate}};
     }
 

--- a/src/tools/dump.cc
+++ b/src/tools/dump.cc
@@ -1041,7 +1041,8 @@ void Tool::Disassemble(SectionIndex section_index,
     }
     if (opcode == Opcode::Block || opcode == Opcode::If ||
         opcode == Opcode::Loop || opcode == Opcode::Else ||
-        opcode == Opcode::Catch || opcode == Opcode::Try) {
+        opcode == Opcode::Catch || opcode == Opcode::Try ||
+        opcode == Opcode::Let) {
       indent += 2;
     }
   }

--- a/test/binary/read_test.cc
+++ b/test/binary/read_test.cc
@@ -1817,6 +1817,27 @@ TEST_F(BinaryReadTest, InstructionList_TryNoEnd) {
        "\x06\x40\07\x0b"_su8);
 }
 
+TEST_F(BinaryReadTest, InstructionList_LetEnd) {
+  ctx.features.enable_function_references();
+
+  OK(Read<InstructionList>,
+     InstructionList{
+         At{"\x17\x40\x00"_su8,
+            I{At{"\x17"_su8, O::Let},
+              At{"\x40\x00"_su8, LetImmediate{At{"\x40"_su8, BT_Void},
+                                              At{"\x00"_su8, LocalsList{}}}}}},
+         At{"\x0b"_su8, I{At{"\x0b"_su8, O::End}}},
+     },
+     "\x17\x40\x00\x0b\x0b"_su8);
+}
+
+TEST_F(BinaryReadTest, InstructionList_LetNoEnd) {
+  ctx.features.enable_function_references();
+
+  Fail(Read<InstructionList>, {{4, "opcode"}, {4, "Unable to read u8"}},
+       "\x17\x40\x00\x0b"_su8);
+}
+
 TEST_F(BinaryReadTest, Instruction_tail_call) {
   ctx.features.enable_tail_call();
 

--- a/test/text/write_test.cc
+++ b/test/text/write_test.cc
@@ -712,6 +712,16 @@ TEST(TextWriteTest, Function_DontOverDedent) {
       Function{{}, {}, InstructionList{I{O::End}, I{O::End}, I{O::End}}, {}});
 }
 
+TEST(TextWriteTest, Function_IndentLet) {
+  ExpectWrite("(func\n  let\n    nop\n  end)"_sv,
+              Function{{},
+                       {},
+                       InstructionList{I{O::Let, LetImmediate{}}, I{O::Nop},
+                                       I{O::End}, I{O::End}},
+                       {}});
+}
+
+
 TEST(TextWriteTest, ElementExpressionList) {
   ExpectWrite("(ref.null) (ref.func 0)"_sv,
               ElementExpressionList{


### PR DESCRIPTION
* binary/read.cc: A let instruction needs to have an `end`, so it should
  push the instruction onto `Context::open_blocks`.
* text/write.h, tools/dump.cc: `let` should indent (along with other
  instructions that require and `end`).