### PR TITLE
fixes a -Wswitch warning about ExternalKind::Tag not having a case in…

### DIFF
--- a/src/binary/types.cc
+++ b/src/binary/types.cc
@@ -123,6 +123,7 @@ At<ReferenceType> ElementSegment::elemtype() const {
       case ExternalKind::Table:
       case ExternalKind::Memory:
       case ExternalKind::Global:
+      case ExternalKind::Tag:
         return ReferenceType{ReferenceKind::Externref};
     }
   } else {


### PR DESCRIPTION
… the switch statement.

I'm not exactly sure if this is the correct fix or not.