### PR TITLE
Update absl submodule to avoid glibc compilation error

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -78,6 +78,5 @@ target_include_directories(libwasp_base
 
 target_link_libraries(libwasp_base
   absl::base
-  absl::container
   absl::hash
 )


### PR DESCRIPTION
Hello,

I'm building wasp into the docker image I use to develop a hobby project and while updating the base layer (Ubuntu 22.04), wasp failed to build due to an error in absl. It seems to be related to the glibc version (https://github.com/abseil/abseil-cpp/issues/952).
Updating the submodule (and removing the link to absl::container which don't exist anymore) fixes the issue for me.

Let me know if you want more details. BR.